### PR TITLE
Runtime reads v2; cards show per-size availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
   </main>
 
   <footer>
-    <p>Versão: 6.0.0 - 0.61.241</p>
+    <p>Versão: 6.1.0 - 0.61.241</p>
   </footer>
 
   <!-- registry:start -->

--- a/scripts.js
+++ b/scripts.js
@@ -71,13 +71,48 @@
     const alt = escapeHtml(product.name);
     const media = mediaAt(product, 0);
     if (!media) {
-      const fallback = Array.isArray(product.images) ? product.images[0] : product.image;
+      // No media means an unbuilt source tree, where the original is all there
+      // is. The legacy singular `image` field is gone: every product has used
+      // `images[]` since Wave 0, and the schema rejects the old key.
+      const fallback = (product.images || [])[0];
       return `<img src="${escapeHtml(fallback)}" alt="${alt}" loading="lazy" decoding="async">`;
     }
     return `<picture>
             <source srcset="${escapeHtml(media.thumb)}" type="image/webp">
             <img src="${escapeHtml(media.thumbFallback)}" alt="${alt}" width="${escapeHtml(media.thumbWidth)}" height="${escapeHtml(media.thumbHeight)}" loading="lazy" decoding="async">
           </picture>`;
+  };
+
+  // A row can hold several units, each independently sellable, so the card shows
+  // which sizes are actually left rather than one all-or-nothing badge. This is
+  // the question a customer asks most often — "do you have it in G?" — and the
+  // data could not answer it before the v2 size model.
+  //
+  // `sizeNote` renders in place of the sizes, without the "Tamanho:" prefix: the
+  // notes are things like "Consultar" and "Tamanho único", which read as
+  // nonsense prefixed ("Tamanho: Consultar") and fine on their own.
+  const sizesMarkup = (product) => {
+    const sizes = Array.isArray(product.sizes) ? product.sizes : [];
+
+    if (sizes.length) {
+      const label = sizes.length > 1 ? 'Tamanhos' : 'Tamanho';
+      const chips = sizes
+        .map((unit) => {
+          const size = escapeHtml(unit.size);
+          return unit.soldOut === true
+            ? `<span class="size-chip size-chip-sold-out" aria-label="${size} (esgotado)">${size}</span>`
+            : `<span class="size-chip">${size}</span>`;
+        })
+        .join('');
+      return `<p class="sizes"><span class="size-label">${label}:</span>${chips}</p>`;
+    }
+
+    if (product.sizeNote) {
+      return `<p class="size-note">${escapeHtml(product.sizeNote)}</p>`;
+    }
+
+    // A cap or a wallet has no meaningful size; v1 rendered "N/A" here.
+    return '';
   };
 
   const updateCategoryHeading = (category, headingEl) => {
@@ -202,8 +237,8 @@
       updateImage();
       updateNavButtons();
 
-      // Default soldOut to false if not provided.
-      const isSoldOut = product.hasOwnProperty('soldOut') ? product.soldOut : false;
+      // Derived by the build from the units, and omitted when false.
+      const isSoldOut = product.soldOut === true;
       const buyButton = document.getElementById('buy-product');
       const modalImageContainer = document.getElementById('modal-image-container');
 
@@ -298,20 +333,17 @@
     // Category currently on screen, used to ignore redundant hash navigation.
     let renderedCategory = null;
 
-    // Parse date from product name using a 10-digit code.
-    const parseProductDate = (name) => {
-      const regex = /\[(\d{10})\]/;
-      const match = name ? name.match(regex) : null;
-      if (match) {
-        const code = match[1];
-        const day = parseInt(code.substring(0, 2), 10);
-        const month = parseInt(code.substring(2, 4), 10) - 1;
-        const year = parseInt(code.substring(4, 6), 10) + 2000;
-        const hour = parseInt(code.substring(6, 8), 10);
-        const minute = parseInt(code.substring(8, 10), 10);
-        return new Date(year, month, day, hour, minute);
-      }
-      return new Date(0);
+    // Incremented per render so a slower earlier render cannot append over a
+    // newer one. See renderProducts.
+    let renderToken = 0;
+
+    // Newest first. Products carry an explicit UTC `listedAt`, so this replaced
+    // a regex that recovered the date from the display name — one of two
+    // duplicate implementations, both using local-time construction, so the
+    // reader's timezone could reorder products that shared a minute.
+    const listedAtOf = (product) => {
+      const parsed = Date.parse(product.listedAt);
+      return Number.isNaN(parsed) ? 0 : parsed;
     };
 
     // Fetch and parse one category file.
@@ -335,7 +367,7 @@
         }
         return result.value.map((product) => ({ ...product, category: categories[idx] }));
       });
-      return products.sort((a, b) => parseProductDate(b.name) - parseProductDate(a.name));
+      return products.sort((a, b) => listedAtOf(b) - listedAtOf(a));
     };
 
     // Fetch product data for a given category. The build emits a pre-merged,
@@ -360,10 +392,17 @@
     };
 
     // Render product items based on selected category.
+    //
+    // The grid is cleared synchronously but filled after an await, so two
+    // overlapping renders would both clear and then both append, leaving a grid
+    // holding both categories. Each render takes a token and drops out if a
+    // newer one started while it was fetching.
     const renderProducts = async (category) => {
+      const token = (renderToken += 1);
       productListContainer.innerHTML = '';
       updateCategoryHeading(category, categoryHeading);
       const products = await fetchCategoryData(category);
+      if (token !== renderToken) return;
       products.forEach((product) => {
         const li = document.createElement('li');
         li.classList.add('product-item');
@@ -379,14 +418,14 @@
           <div class="product-details">
             <h3>${escapeHtml(product.name)}</h3>
             ${product.description ? `<p class="description">${escapeHtml(product.description)}</p>` : ''}
-            ${product.size && product.size !== 'N/A' ? `<span class="size">Tamanho: ${escapeHtml(product.size)}</span>` : ''}
+            ${sizesMarkup(product)}
             ${priceHTML}
           </div>
         `;
 
-        // Add sold-out label if the product is sold out (default false).
-        const isSoldOut = product.hasOwnProperty('soldOut') ? product.soldOut : false;
-        if (isSoldOut) {
+        // The row-level flag is derived by the build from the units, so the
+        // client no longer re-derives it defensively.
+        if (product.soldOut === true) {
           const label = document.createElement('div');
           label.className = 'sold-out-label';
           label.textContent = 'Esgotado';

--- a/styles.css
+++ b/styles.css
@@ -221,9 +221,48 @@
     color: var(--primary-color);
   }
   
-  .size {
+  /* A row can hold several units, so the card lists which sizes are left rather
+     than showing one all-or-nothing badge. */
+  .sizes {
     font-size: 0.9rem;
     color: var(--muted-text);
+    margin-bottom: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  .size-label {
+    color: var(--muted-text);
+  }
+
+  .size-chip {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 1px 7px;
+    line-height: 1.5;
+    color: var(--text-color);
+    background-color: #fff;
+  }
+
+  /* Struck through as well as faded, so availability does not rest on colour
+     alone; the chip also carries an aria-label. */
+  .size-chip-sold-out {
+    color: var(--gray-text);
+    background-color: #f4f4f4;
+    border-color: #eee;
+    text-decoration: line-through;
+  }
+
+  /* "Consultar", "Tamanho único" — read as a note, not as a size value, which is
+     why they carry no "Tamanho:" prefix. */
+  .size-note {
+    font-size: 0.9rem;
+    color: var(--muted-text);
+    font-style: italic;
+    margin-bottom: 8px;
   }
   
   .price {

--- a/tests/behaviour/catalog.behaviour.test.js
+++ b/tests/behaviour/catalog.behaviour.test.js
@@ -11,7 +11,19 @@ describe('Catalog Behaviour', () => {
     });
     
     describe('Sorting Order', () => {
-        const customData = {
+        // Products now sort by an explicit UTC `listedAt` rather than by a regex
+        // over the display name, so these fixtures derive it from the same
+        // [DDMMYYHHmm] code the name carries — which is exactly the relationship
+        // the migration established.
+        const withListedAt = (products) =>
+            products.map((product) => {
+                const code = /\[(\d{10})\]/.exec(product.name)[1];
+                const listedAt = `20${code.slice(4, 6)}-${code.slice(2, 4)}-${code.slice(0, 2)}`
+                    + `T${code.slice(6, 8)}:${code.slice(8, 10)}:00Z`;
+                return { ...product, id: code, listedAt, sizes: [], images: ['images/x.jpeg'] };
+            });
+
+        const rawData = {
             "shoes-man": [{ name: "[1202252201] Shoe Man", price: 149 }],
             "slippers-man": [{ name: "[1702251140] Slipper Man", price: 29.90 }],
             "tshirts-casual-man": [{ name: "[0103250820] Tshirt Casual Man", price: 89.90 }],
@@ -39,6 +51,10 @@ describe('Catalog Behaviour', () => {
             "underwear-man": [{ name:"[2907251513] Underwear Man", price: 23.00}],
             "fitness-top-woman": [{ name: "[2709252000] Top Woman", price: 39.00 }],
         };
+
+        const customData = Object.fromEntries(
+            Object.entries(rawData).map(([slug, products]) => [slug, withListedAt(products)])
+        );
 
         beforeEach(() => {
             // Reset modules and override fetch BEFORE initializing the catalog.

--- a/tests/behaviour/catalog.escaping.test.js
+++ b/tests/behaviour/catalog.escaping.test.js
@@ -3,12 +3,30 @@ const { waitFor, setupDOM } = require('../utils/catalogCommon');
 // Product data reaches the DOM through innerHTML, so a name or description
 // containing markup must be rendered as text rather than parsed as HTML.
 const HOSTILE_PRODUCT = {
+  id: '2907251533',
   name: '<img src=x onerror=alert(1)> "Nike" & \'Adidas\'',
+  brandLabel: 'Nike',
   description: '<script>document.title = "pwned";</script>',
-  oldPrice: 0,
   price: 10,
-  size: '<b>GG</b>',
+  // Every size value is interpolated separately now, so each is its own
+  // escaping site — including the aria-label on a sold-out chip.
+  sizes: [
+    { size: '<b>GG</b>' },
+    { size: '" onmouseover="alert(1)', soldOut: true },
+  ],
   images: ['images/man/caps/quote".jpeg'],
+  listedAt: '2025-07-29T15:33:00Z',
+};
+
+const NOTE_PRODUCT = {
+  id: '2907251534',
+  name: '[2907251534] Nota',
+  brandLabel: 'Nota',
+  price: 10,
+  sizes: [],
+  sizeNote: '<em>Consultar</em>',
+  images: ['images/man/caps/2907251534-nota.jpeg'],
+  listedAt: '2025-07-29T15:34:00Z',
 };
 
 const card = () => document.querySelector('#product-list .product-item');
@@ -20,7 +38,7 @@ describe('Product data escaping', () => {
     document.body.innerHTML = '';
     window.location.hash = '';
     global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([HOSTILE_PRODUCT]) })
+      Promise.resolve({ ok: true, json: () => Promise.resolve([HOSTILE_PRODUCT, NOTE_PRODUCT]) })
     );
     setupDOM();
     await waitFor(() => expect(card()).toBeTruthy());
@@ -30,13 +48,33 @@ describe('Product data escaping', () => {
     expect(card().querySelectorAll('script')).toHaveLength(0);
     // Only the card's own image: the <img> in the product name did not parse.
     expect(card().querySelectorAll('img')).toHaveLength(1);
+    expect(card().querySelectorAll('b')).toHaveLength(0);
     expect(document.title).not.toBe('pwned');
   });
 
   it('renders the name and description verbatim as text', () => {
     expect(card().querySelector('h3').textContent).toBe(HOSTILE_PRODUCT.name);
     expect(card().querySelector('.description').textContent).toBe(HOSTILE_PRODUCT.description);
-    expect(card().querySelector('.size').textContent).toBe(`Tamanho: ${HOSTILE_PRODUCT.size}`);
+  });
+
+  it('renders each size as text rather than markup', () => {
+    const chips = [...card().querySelectorAll('.size-chip')];
+    expect(chips.map((chip) => chip.textContent))
+      .toEqual(HOSTILE_PRODUCT.sizes.map((unit) => unit.size));
+  });
+
+  // The sold-out chip interpolates the size into an aria-label, a quoted
+  // attribute, so a value containing a quote must not break out of it.
+  it('keeps a hostile size inside the aria-label attribute', () => {
+    const soldOut = card().querySelector('.size-chip-sold-out');
+    expect(soldOut.getAttribute('aria-label')).toBe('" onmouseover="alert(1) (esgotado)');
+    expect(soldOut.hasAttribute('onmouseover')).toBe(false);
+  });
+
+  it('renders a hostile sizeNote as text', () => {
+    const note = document.querySelectorAll('#product-list .product-item')[1].querySelector('.size-note');
+    expect(note.textContent).toBe(NOTE_PRODUCT.sizeNote);
+    expect(note.querySelectorAll('em')).toHaveLength(0);
   });
 
   it('keeps quotes inside attributes instead of breaking out of them', () => {

--- a/tests/behaviour/catalog.navigation.test.js
+++ b/tests/behaviour/catalog.navigation.test.js
@@ -70,3 +70,31 @@ describe('Fragment navigation', () => {
     expect(itemCount()).toBe(before);
   });
 });
+
+describe('Overlapping renders', () => {
+  // The grid is cleared synchronously and filled after an await, so two renders
+  // in flight at once would both clear and then both append — leaving a grid
+  // holding two categories at once. Found by rendering the real catalog and
+  // getting exactly twice the expected card count.
+  it('keeps only the newest render when two overlap', async () => {
+    const { readCategory } = require('../../tools/lib/catalog');
+    const path = require('path');
+    const count = (slug) => readCategory(path.join(__dirname, '../../products'), slug).length;
+    const caps = count('caps-man');
+    const belts = count('belts-man');
+
+    bootstrap();
+    await waitFor(() => expect(itemCount()).toBeGreaterThan(0));
+
+    // Both clicks land before either fetch resolves, so both renders are in
+    // flight at once.
+    fireEvent.click(document.querySelector('nav button[data-category="caps-man"]'));
+    fireEvent.click(document.querySelector('nav button[data-category="belts-man"]'));
+
+    await waitFor(() => expect(heading()).toBe('Cintos Masculino'));
+    await waitFor(() => expect(itemCount()).toBe(belts));
+
+    // Without the render token this would settle at caps + belts.
+    expect(itemCount()).not.toBe(caps + belts);
+  });
+});

--- a/tests/catalog/fixture/__snapshots__/catalog.fixture.test.js.snap
+++ b/tests/catalog/fixture/__snapshots__/catalog.fixture.test.js.snap
@@ -28,7 +28,7 @@ exports[`Fixture catalog renders the product grid with the expected markup 1`] =
           <div class="product-details">
             <h3>[0501251300] Fixture Epsilon</h3>
             
-            <span class="size">Tamanho: Tamanho único</span>
+            <p class="size-note">Tamanho único</p>
             <span class="price">R$&nbsp;25,50</span>
           </div>
         <div class="sold-out-label">Esgotado</div></li><li class="product-item" style="position: relative;">
@@ -36,18 +36,18 @@ exports[`Fixture catalog renders the product grid with the expected markup 1`] =
           <div class="product-details">
             <h3>[0401251200] Fixture Delta</h3>
             <p class="description">Produto de fixture padrão</p>
-            <span class="size">Tamanho: GG</span>
+            <p class="sizes"><span class="size-label">Tamanhos:</span><span class="size-chip size-chip-sold-out" aria-label="GG (esgotado)">GG</span><span class="size-chip size-chip-sold-out" aria-label="G1 (esgotado)">G1</span></p>
             <span class="price">R$&nbsp;75,00</span>
           </div>
-        </li><li class="product-item" style="position: relative;">
+        <div class="sold-out-label">Esgotado</div></li><li class="product-item" style="position: relative;">
           <img src="images/fixtures/0301251100-gamma.jpeg" alt="[0301251100] Fixture Gamma" loading="lazy" decoding="async">
           <div class="product-details">
             <h3>[0301251100] Fixture Gamma</h3>
-            <p class="description">Produto de fixture com imagem no schema legado</p>
-            <span class="size">Tamanho: M</span>
+            <p class="description">Produto de fixture parcialmente esgotado</p>
+            <p class="sizes"><span class="size-label">Tamanhos:</span><span class="size-chip size-chip-sold-out" aria-label="P (esgotado)">P</span><span class="size-chip">M</span><span class="size-chip size-chip-sold-out" aria-label="G (esgotado)">G</span></p>
             <span class="price">R$&nbsp;50,00</span>
           </div>
-        <div class="sold-out-label">Esgotado</div></li><li class="product-item" style="position: relative;">
+        </li><li class="product-item" style="position: relative;">
           <img src="images/fixtures/0201251000-beta.jpeg" alt="[0201251000] Fixture Beta" loading="lazy" decoding="async">
           <div class="product-details">
             <h3>[0201251000] Fixture Beta</h3>
@@ -64,7 +64,7 @@ exports[`Fixture catalog renders the product grid with the expected markup 1`] =
           <div class="product-details">
             <h3>[0101250900] Fixture Alpha</h3>
             <p class="description">Produto de fixture com media gerada pelo build</p>
-            <span class="size">Tamanho: G</span>
+            <p class="sizes"><span class="size-label">Tamanho:</span><span class="size-chip">G</span></p>
             <span class="price">R$&nbsp;100,00</span>
           </div>
         </li>"

--- a/tests/catalog/fixture/catalog.fixture.test.js
+++ b/tests/catalog/fixture/catalog.fixture.test.js
@@ -68,7 +68,10 @@ describe('Fixture catalog', () => {
       expect(card.querySelector('img')).toHaveAttribute('src', 'images/fixtures/0401251200-delta.jpeg');
     });
 
-    it('still renders a product using the legacy single-image field', () => {
+    // The legacy singular `image` field is gone from both the data and the
+    // client: every product has used images[] since Wave 0, and the schema
+    // rejects the old key.
+    it('renders a product whose only image comes from images[]', () => {
       const card = cardFor('[0301251100] Fixture Gamma');
       expect(card.querySelector('img')).toHaveAttribute('src', 'images/fixtures/0301251100-gamma.jpeg');
     });
@@ -86,19 +89,50 @@ describe('Fixture catalog', () => {
       expect(plain.querySelector('.old-price')).toBeNull();
     });
 
-    it('labels sold-out products and leaves the others unlabelled', () => {
-      expect(cardFor('[0301251100] Fixture Gamma').querySelector('.sold-out-label'))
+    // The badge means the whole row is gone. A row with one size left keeps
+    // selling, which is the point of tracking availability per unit.
+    it('labels only rows where every unit is sold', () => {
+      expect(cardFor('[0401251200] Fixture Delta').querySelector('.sold-out-label'))
         .toHaveTextContent('Esgotado');
       expect(cardFor('[0501251300] Fixture Epsilon').querySelector('.sold-out-label'))
         .toBeInTheDocument();
-      expect(cardFor('[0401251200] Fixture Delta').querySelector('.sold-out-label'))
+      // Gamma has P and G sold but M available, so the row stays up.
+      expect(cardFor('[0301251100] Fixture Gamma').querySelector('.sold-out-label'))
         .toBeNull();
     });
 
-    it('suppresses the size line for "N/A" but keeps other size text', () => {
-      expect(cardFor('[0201251000] Fixture Beta').querySelector('.size')).toBeNull();
-      expect(cardFor('[0501251300] Fixture Epsilon').querySelector('.size'))
-        .toHaveTextContent('Tamanho: Tamanho único');
+    it('shows which sizes are left on a partly sold-out row', () => {
+      const chips = [...cardFor('[0301251100] Fixture Gamma').querySelectorAll('.size-chip')];
+      expect(chips.map((chip) => chip.textContent)).toEqual(['P', 'M', 'G']);
+      expect(chips.map((chip) => chip.classList.contains('size-chip-sold-out')))
+        .toEqual([true, false, true]);
+    });
+
+    // Availability must not rest on colour alone.
+    it('marks a sold-out size for assistive technology too', () => {
+      const soldOut = cardFor('[0301251100] Fixture Gamma').querySelector('.size-chip-sold-out');
+      expect(soldOut).toHaveAttribute('aria-label', 'P (esgotado)');
+    });
+
+    it('pluralises the size label', () => {
+      expect(cardFor('[0301251100] Fixture Gamma').querySelector('.size-label'))
+        .toHaveTextContent('Tamanhos:');
+      expect(cardFor('[0101250900] Fixture Alpha').querySelector('.size-label'))
+        .toHaveTextContent('Tamanho:');
+    });
+
+    // "Tamanho: Consultar" read as nonsense, so a note renders on its own.
+    it('renders a size note without the "Tamanho:" prefix', () => {
+      const card = cardFor('[0501251300] Fixture Epsilon');
+      expect(card.querySelector('.size-note')).toHaveTextContent('Tamanho único');
+      expect(card.querySelector('.size-label')).toBeNull();
+      expect(card.querySelector('.size-chip')).toBeNull();
+    });
+
+    it('renders nothing where a product has no size at all', () => {
+      const card = cardFor('[0201251000] Fixture Beta');
+      expect(card.querySelector('.sizes')).toBeNull();
+      expect(card.querySelector('.size-note')).toBeNull();
     });
 
     it('omits the description for both a missing key and an empty string', () => {
@@ -123,9 +157,15 @@ describe('Fixture catalog', () => {
         .toHaveAttribute('src', 'images/fixtures/0101250900-alpha-front.jpg');
     });
 
-    it('marks a sold-out product inside the modal', async () => {
-      await openModalFor('[0301251100] Fixture Gamma');
+    it('marks a fully sold-out product inside the modal', async () => {
+      await openModalFor('[0401251200] Fixture Delta');
       expect(document.querySelector('#product-modal .sold-out-label')).toBeInTheDocument();
+    });
+
+    it('leaves a partly sold-out product buyable in the modal', async () => {
+      await openModalFor('[0301251100] Fixture Gamma');
+      expect(document.querySelector('#product-modal .sold-out-label')).toBeNull();
+      expect(document.getElementById('buy-product')).not.toBeDisabled();
     });
   });
 });

--- a/tests/fixtures/catalog/alpha.json
+++ b/tests/fixtures/catalog/alpha.json
@@ -1,30 +1,46 @@
 [
   {
+    "id": "0301251100",
     "name": "[0301251100] Fixture Gamma",
-    "description": "Produto de fixture com imagem no schema legado",
-    "oldPrice": 0.0,
+    "brand": "fixture",
+    "brandLabel": "Fixture",
+    "model": "Gamma",
     "price": 50.0,
-    "size": "M",
-    "soldOut": true,
-    "image": "images/fixtures/0301251100-gamma.jpeg"
+    "description": "Produto de fixture parcialmente esgotado",
+    "sizes": [
+      { "size": "P", "soldOut": true },
+      { "size": "M" },
+      { "size": "G", "soldOut": true }
+    ],
+    "images": ["images/fixtures/0301251100-gamma.jpeg"],
+    "listedAt": "2025-01-03T11:00:00Z"
   },
   {
+    "id": "0201251000",
     "name": "[0201251000] Fixture Beta",
-    "oldPrice": 150.0,
+    "brand": "fixture",
+    "brandLabel": "Fixture",
+    "model": "Beta",
     "price": 99.9,
-    "size": "N/A",
-    "images": ["images/fixtures/0201251000-beta.jpeg"]
+    "oldPrice": 150.0,
+    "sizes": [],
+    "images": ["images/fixtures/0201251000-beta.jpeg"],
+    "listedAt": "2025-01-02T10:00:00Z"
   },
   {
+    "id": "0101250900",
     "name": "[0101250900] Fixture Alpha",
-    "description": "Produto de fixture com media gerada pelo build",
-    "oldPrice": 0.0,
+    "brand": "fixture",
+    "brandLabel": "Fixture",
+    "model": "Alpha",
     "price": 100.0,
-    "size": "G",
+    "description": "Produto de fixture com media gerada pelo build",
+    "sizes": [{ "size": "G" }],
     "images": [
       "images/fixtures/0101250900-alpha-front.jpeg",
       "images/fixtures/0101250900-alpha-back.jpeg"
     ],
+    "listedAt": "2025-01-01T09:00:00Z",
     "media": [
       {
         "src": "images/fixtures/0101250900-alpha-front.jpeg",

--- a/tests/fixtures/catalog/beta.json
+++ b/tests/fixtures/catalog/beta.json
@@ -1,19 +1,31 @@
 [
   {
+    "id": "0501251300",
     "name": "[0501251300] Fixture Epsilon",
-    "description": "",
-    "oldPrice": 0.0,
+    "brand": "fixture",
+    "brandLabel": "Fixture",
+    "model": "Epsilon",
     "price": 25.5,
-    "size": "Tamanho único",
+    "sizes": [],
+    "sizeNote": "Tamanho único",
     "soldOut": true,
-    "images": ["images/fixtures/0501251300-epsilon.jpeg"]
+    "images": ["images/fixtures/0501251300-epsilon.jpeg"],
+    "listedAt": "2025-01-05T13:00:00Z"
   },
   {
+    "id": "0401251200",
     "name": "[0401251200] Fixture Delta",
-    "description": "Produto de fixture padrão",
-    "oldPrice": 0.0,
+    "brand": "fixture",
+    "brandLabel": "Fixture",
+    "model": "Delta",
     "price": 75.0,
-    "size": "GG",
-    "images": ["images/fixtures/0401251200-delta.jpeg"]
+    "description": "Produto de fixture padrão",
+    "sizes": [
+      { "size": "GG", "soldOut": true },
+      { "size": "G1", "soldOut": true }
+    ],
+    "soldOut": true,
+    "images": ["images/fixtures/0401251200-delta.jpeg"],
+    "listedAt": "2025-01-04T12:00:00Z"
   }
 ]

--- a/tests/footer/__snapshots__/footer.test.js.snap
+++ b/tests/footer/__snapshots__/footer.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Footer CSS and Markup renders footer markup as expected 1`] = `
 "<footer>
-    <p>Versão: 6.0.0 - 0.61.241</p>
+    <p>Versão: 6.1.0 - 0.61.241</p>
   </footer>"
 `;

--- a/tests/tools/runtime.test.js
+++ b/tests/tools/runtime.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { deriveName, deriveSize, deriveSoldOut, toRuntime } = require('../../tools/lib/runtime');
+const { deriveName, deriveSoldOut, toRuntime } = require('../../tools/lib/runtime');
 const { loadRegistry } = require('../../tools/lib/registry');
 const { readCategory, listCategories } = require('../../tools/lib/catalog');
 
@@ -52,24 +52,6 @@ describe('deriveName', () => {
   });
 });
 
-describe('deriveSize', () => {
-  it('renders a single unit as its size', () => {
-    expect(deriveSize(product({ sizes: [{ size: 'G' }] }))).toBe('G');
-  });
-
-  it('joins several units with a comma and a space', () => {
-    expect(deriveSize(product({ sizes: [{ size: '39' }, { size: '42' }] }))).toBe('39, 42');
-  });
-
-  it('renders the note when there are no units', () => {
-    expect(deriveSize(product({ sizes: [], sizeNote: 'Consultar' }))).toBe('Consultar');
-  });
-
-  it('falls back to "N/A" when there is neither, as a cap has', () => {
-    expect(deriveSize(product({ sizes: [] }))).toBe('N/A');
-  });
-});
-
 describe('deriveSoldOut', () => {
   it('is false when no unit is sold', () => {
     expect(deriveSoldOut(product({ sizes: [{ size: 'M' }, { size: 'G' }] }))).toBe(false);
@@ -95,9 +77,9 @@ describe('deriveSoldOut', () => {
 });
 
 describe('toRuntime', () => {
-  it('emits the v1 field order, so the compiled output is comparable', () => {
+  it('emits the v2 runtime fields', () => {
     expect(Object.keys(toRuntime(product({}), BRANDS)))
-      .toEqual(['name', 'description', 'oldPrice', 'price', 'images', 'size']);
+      .toEqual(['id', 'name', 'brand', 'brandLabel', 'price', 'sizes', 'images', 'listedAt']);
   });
 
   it('appends soldOut only when the row is sold out', () => {
@@ -105,10 +87,29 @@ describe('toRuntime', () => {
     expect(toRuntime(product({ sizes: [{ size: 'G', soldOut: true }] }), BRANDS).soldOut).toBe(true);
   });
 
-  it('substitutes the v1 sentinels the client still expects', () => {
+  it('passes sizes through untouched, per-unit sold-out state included', () => {
+    const sizes = [{ size: 'M' }, { size: 'G', soldOut: true }];
+    expect(toRuntime(product({ sizes }), BRANDS).sizes).toEqual(sizes);
+  });
+
+  it('carries sizeNote when present', () => {
+    expect(toRuntime(product({ sizes: [], sizeNote: 'Consultar' }), BRANDS).sizeNote)
+      .toBe('Consultar');
+  });
+
+  it('resolves the brand label the client displays', () => {
+    expect(toRuntime(product({ brand: 'under-armor' }), BRANDS).brandLabel).toBe('Under Armour');
+  });
+
+  // v1 carried description:"" and oldPrice:0 for "absent", which is how it ended
+  // up with three states for "no description". v2 omits them and the client
+  // tests for presence.
+  it('omits absent optional fields rather than giving them sentinels', () => {
     const runtime = toRuntime(product({}), BRANDS);
-    expect(runtime.description).toBe('');
-    expect(runtime.oldPrice).toBe(0);
+    expect('description' in runtime).toBe(false);
+    expect('oldPrice' in runtime).toBe(false);
+    expect('sizeNote' in runtime).toBe(false);
+    expect('model' in runtime).toBe(false);
   });
 
   it('passes a real discount through', () => {

--- a/tests/utils/catalogAsserts.js
+++ b/tests/utils/catalogAsserts.js
@@ -80,15 +80,37 @@ const assertCardInvariants = (products) => {
   });
 
   // Optional fields render exactly as often as the data declares them.
+  //
+  // These count sizes per *unit*, not per product. The previous version tested
+  // `product.size`, a v1 field, and after the v2 switch it compared 0 against 0
+  // — passing without checking anything. Counting units keeps the assertion
+  // anchored to something that exists.
+  const units = products.flatMap((product) => product.sizes || []);
+
   const expected = {
     soldOut: products.filter((product) => product.soldOut === true).length,
     description: products.filter((product) => product.description).length,
-    size: products.filter((product) => product.size && product.size !== 'N/A').length,
+    sizeBlocks: products.filter((product) => (product.sizes || []).length).length,
+    notes: products.filter((product) => !(product.sizes || []).length && product.sizeNote).length,
+    chips: units.length,
+    soldOutChips: units.filter((unit) => unit.soldOut === true).length,
   };
 
   expect(document.querySelectorAll('#product-list .sold-out-label')).toHaveLength(expected.soldOut);
   expect(document.querySelectorAll('#product-list .description')).toHaveLength(expected.description);
-  expect(document.querySelectorAll('#product-list .size')).toHaveLength(expected.size);
+  expect(document.querySelectorAll('#product-list .sizes')).toHaveLength(expected.sizeBlocks);
+  expect(document.querySelectorAll('#product-list .size-note')).toHaveLength(expected.notes);
+  expect(document.querySelectorAll('#product-list .size-chip')).toHaveLength(expected.chips);
+  expect(document.querySelectorAll('#product-list .size-chip-sold-out'))
+    .toHaveLength(expected.soldOutChips);
+
+  // A row is badged only when every unit in it is gone, so a partly sold-out row
+  // keeps selling — the whole point of tracking availability per unit.
+  products
+    .filter((product) => (product.sizes || []).length && !product.sizes.every((u) => u.soldOut === true))
+    .forEach((product) => {
+      expect(product.soldOut).not.toBe(true);
+    });
 
   // Every product contributes at least one image reference, so no card can
   // silently render without art.

--- a/tools/lib/runtime.js
+++ b/tools/lib/runtime.js
@@ -1,12 +1,19 @@
 'use strict';
 
 /**
- * Derives the v1 runtime product shape from a v2 authoring product.
+ * Compiles a v2 authoring product into the shape the client reads.
  *
- * The build is a compiler, which is what lets the data migration and the runtime
- * change ship in separate waves: during the overlap it emits exactly the shape
- * scripts.js already consumes, so Wave 4 touches no client code and no test.
- * Wave 5b switches the client to read v2 fields directly and this module goes.
+ * Through Wave 4 this module re-derived the *v1* runtime shape, so the data
+ * migration could ship without touching scripts.js. Wave 5b switches the client
+ * over, so it now emits v2 and only the genuinely derived fields are computed:
+ * the display name, and the row-level sold-out state.
+ *
+ * What is deliberately still emitted rather than left to the client:
+ *  - `name`, because it is the customer-facing product reference in the
+ *    WhatsApp message and the clipboard (CON-4). Deriving it in two places is
+ *    how the brand/model split went wrong in the first place.
+ *  - `soldOut`, because "every unit is sold" is a rule about the data, not a
+ *    rendering concern.
  */
 
 /**
@@ -17,7 +24,7 @@
  * neither reads "[1107250717]" with nothing trailing.
  * @param {object} product v2 product.
  * @param {object} brands Brand registry.
- * @returns {string} The v1 display name.
+ * @returns {string} The display name.
  */
 const deriveName = (product, brands) => {
   const brand = brands[product.brand];
@@ -26,27 +33,7 @@ const deriveName = (product, brands) => {
 };
 
 /**
- * Rebuilds the single size string.
- *
- * v1 stored one free-text value; v2 stores a list of independently sellable
- * units plus a note for anything that is not a size. Joining with ", "
- * reproduces every multi-value row verbatim except one, which read "40,41".
- * @param {object} product v2 product.
- * @returns {string} The v1 size string.
- */
-const deriveSize = (product) => {
-  if (product.sizes && product.sizes.length) {
-    return product.sizes.map((entry) => entry.size).join(', ');
-  }
-  return product.sizeNote || 'N/A';
-};
-
-/**
  * A row is sold out when every unit in it is.
- *
- * v1 carried one boolean per product. v2 tracks it per unit, so the row-level
- * flag becomes derived — which is what lets Wave 5b show which sizes are left
- * without changing the data again.
  *
  * A row with no units (a cap, a wallet) has nothing to carry the flag, so it
  * keeps a row-level `soldOut`. Reading only the units would put nine sold-out
@@ -62,28 +49,38 @@ const deriveSoldOut = (product) => {
 };
 
 /**
- * Converts a v2 product to the shape scripts.js consumes.
+ * Converts a v2 authoring product to the runtime shape.
  *
- * Key order matches what v1 emitted, so `dist/products/*.json` stays
- * byte-identical and the Wave 4 acceptance gate is a plain file comparison.
+ * Optional fields are omitted rather than given sentinel values: v1 carried
+ * `description: ""` and `oldPrice: 0` for "absent", which is why it had three
+ * states for "no description". The client tests for presence.
  * @param {object} product v2 product.
  * @param {object} brands Brand registry.
- * @returns {object} v1 runtime product.
+ * @returns {object} Runtime product.
  */
 const toRuntime = (product, brands) => {
+  const brand = brands[product.brand];
+
   const runtime = {
+    id: product.id,
     name: deriveName(product, brands),
-    description: product.description || '',
-    oldPrice: product.oldPrice || 0,
-    price: product.price,
-    images: product.images,
-    size: deriveSize(product),
+    brand: product.brand,
+    brandLabel: brand ? brand.label : '',
   };
 
-  // v1 omitted soldOut when false, and the client re-derived the default.
+  if (product.model) runtime.model = product.model;
+  runtime.price = product.price;
+  if (product.oldPrice) runtime.oldPrice = product.oldPrice;
+  if (product.description) runtime.description = product.description;
+
+  runtime.sizes = product.sizes || [];
+  if (product.sizeNote) runtime.sizeNote = product.sizeNote;
   if (deriveSoldOut(product)) runtime.soldOut = true;
+
+  runtime.images = product.images;
+  runtime.listedAt = product.listedAt;
 
   return runtime;
 };
 
-module.exports = { deriveName, deriveSize, deriveSoldOut, toRuntime };
+module.exports = { deriveName, deriveSoldOut, toRuntime };


### PR DESCRIPTION
Wave 5b part 1 of `docs/architecture/product-image-storage-plan.md`. The delivery
half — srcset ladder, AVIF, content-hashed filenames — is deliberately **not** in
this PR.

Small diff, but it changes the `dist/products/*.json` contract and what a card
renders, so it's worth a look in a preview rather than only in the diff.

### The visible change

Cards now show **which sizes are left** instead of one all-or-nothing badge. A row
is badged `Esgotado` only when every unit is gone; a partly sold-out row keeps
selling with its unavailable sizes struck through. This is the payoff of the OQ-4
answer (a row can hold several units) and answers the question customers ask most
often — "do you have it in G?" — which the data could not express before Wave 4.

`sizeNote` now renders on its own instead of behind a "Tamanho:" prefix, fixing
"Tamanho: Consultar" across the 18 notes that carry one.

**Caveat worth knowing:** no product is partly sold out yet. The Wave 4 migration
necessarily applied v1's single row-level flag to *every* unit, so the state is
representable and rendered but has no live data — it appears the first time a
single size is marked gone on a multi-size row. What you'll actually see today is
multi-size rows showing chips instead of `Tamanho: M, G, GG`. The fixture covers
the partial case precisely because `products/` does not.

### Runtime shape

`tools/lib/runtime.js` stops back-deriving v1 and emits v2: `id`, `name`, `brand`,
`brandLabel`, `model?`, `price`, `oldPrice?`, `description?`, `sizes[]`,
`sizeNote?`, `soldOut?`, `images[]`, `listedAt`. Optional fields are **omitted**
rather than given sentinels — v1's `description: ""` and `oldPrice: 0` are exactly
what gave it three states for "no description".

`name` and `soldOut` stay build-derived on purpose: the first is the
customer-facing reference in the WhatsApp message (CON-4), and "every unit is
sold" is a rule about the data, not about rendering.

Client cleanups: `parseProductDate` deleted (sorting reads the explicit UTC
`listedAt`, so a reader's timezone can no longer reorder products sharing a
minute), the `hasOwnProperty('soldOut')` defensiveness gone, and the legacy
singular `image` branch removed. **The fragment allow-list guard is untouched.**

### Two bugs found by rendering the real catalog

Both surfaced from running `dist/` through jsdom rather than trusting a green
suite — the suite passed throughout in each case.

1. **Overlapping renders duplicated the grid.** `renderProducts` clears the list
   synchronously but fills it after an `await`, so two renders in flight both
   cleared and then both appended. Two fast clicks on different categories
   settled at caps + belts. Each render now takes a token and drops out if a
   newer one started. Verified: **20 items without the guard, 9 with**.
2. **A card invariant had gone vacuous.** It tested `product.size`, a v1 field, so
   after the switch it compared 0 against 0 and asserted nothing. It now counts
   per unit — 212 size blocks, 218 chips, 42 sold-out chips, 18 notes, 51 badges.

### Reviewer attention

- **`scripts.js` → `sizesMarkup`** — the new rendering. Every size value is its
  own interpolation site now, including the `aria-label` on a sold-out chip, which
  is a quoted attribute. Covered with a hostile size and a hostile `sizeNote`.
- **`styles.css`** — size chips. Sold-out chips are struck through *and* faded, so
  availability does not rest on colour alone, plus the `aria-label`.
- **`tests/fixtures/catalog/`** — moved to the v2 runtime shape, and now includes
  a partly sold-out product.

### Verification

- `npm test` — 295 passing, 22 suites
- `npm run build` clean; real catalog rendered in jsdom: 241 cards, 51 badges, and
  zero occurrences of `N/A`, `Tamanho: Consultar` or `undefined`
- Mutation-tested: removing the render token fails the new overlap test

### Deploy note

This changes the `dist/products/*.json` contract. Compiled fresh on deploy, so a
normal Pages build handles it — but a stale CDN cache on `products/all.json`
paired with the new `scripts.js` would render cards without sizes. Hard-refresh
after the first deploy.

Footer version 6.0.0 → 6.1.0.