### PR TITLE
Non-developer authoring (Wave 6 — the goal)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-product.yml
+++ b/.github/ISSUE_TEMPLATE/add-product.yml
@@ -1,0 +1,154 @@
+# Generated from catalog/categories.json and catalog/brands.json by
+# `node tools/sync-issue-form.js`. Do not edit by hand; the build fails when
+# this file is stale. Add a category or brand to the registry and re-run.
+name: Adicionar produto
+description: Cadastrar um novo produto no catálogo
+title: "Novo produto: "
+labels: ["novo-produto"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Preencha os campos abaixo e **anexe a foto do produto** no último campo.
+        Ao enviar, um robô cria a alteração e abre um Pull Request para revisão.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: "Categoria"
+      description: Onde o produto aparece no catálogo
+      options:
+        - "Bermudas Básica Masculina"
+        - "Bermudas Jeans Feminina"
+        - "Bermudas Jeans Masculina"
+        - "Bermudas Moletom Masculina"
+        - "Bermudas Tactel Masculina"
+        - "Blusas Feminina"
+        - "Blusas Masculina"
+        - "Bonés Masculino"
+        - "Calças Jeans Feminina"
+        - "Calças Jeans Masculina"
+        - "Calças Legging Feminina"
+        - "Calças Moletom Masculina"
+        - "Camisetas Casuais Masculina"
+        - "Camisetas Dry Fit Masculina"
+        - "Camisetas Polo Masculina"
+        - "Camisetas Sociais Masculina"
+        - "Carteiras Masculina"
+        - "Chinelos"
+        - "Cintos Masculino"
+        - "Conjuntos Moletom Infantil"
+        - "Cuecas Masculina"
+        - "Meias Masculina"
+        - "Regatas Casuais Masculina"
+        - "Regatas Dry Fit Masculina"
+        - "Tênis"
+        - "Top Feminino"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: brand
+    attributes:
+      label: "Marca"
+      description: Escolha "Sem marca" se o produto não tem marca
+      options:
+        - "Sem marca"
+        - "Abercrombie"
+        - "Adidas"
+        - "Aramis"
+        - "Armani"
+        - "Armani Exchange"
+        - "Asics"
+        - "Austman"
+        - "Balmain"
+        - "Brooksfield"
+        - "Burberry"
+        - "Calvin Klein"
+        - "Diesel"
+        - "Dolce & Gabbana"
+        - "Emporio Armani"
+        - "Gucci"
+        - "Hang Loose"
+        - "Hugo Boss"
+        - "Hurley"
+        - "Jordan"
+        - "Lacoste"
+        - "Louis Vuitton"
+        - "Mizuno"
+        - "New Balance"
+        - "Nike"
+        - "Oakley"
+        - "Polo"
+        - "Puma"
+        - "Quiksilver"
+        - "Ralph Lauren"
+        - "Reserva"
+        - "Ricardo Almeida"
+        - "Sergio K"
+        - "Tommy Hilfiger"
+        - "Under Armour"
+        - "Vans"
+        - "Versace"
+        - "XTC"
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: "Modelo"
+      description: Linha do produto, quando houver. Por exemplo, Shox ou Campus
+      placeholder: Shox
+
+  - type: input
+    id: price
+    attributes:
+      label: "Preço"
+      description: Preço de venda, em reais
+      placeholder: 89,90
+    validations:
+      required: true
+
+  - type: input
+    id: old-price
+    attributes:
+      label: "Preço antigo"
+      description: Só preencha se o produto está com desconto. Precisa ser maior que o preço
+      placeholder: 129,90
+
+  - type: input
+    id: sizes
+    attributes:
+      label: "Tamanhos"
+      description: |
+        Os tamanhos disponíveis, separados por vírgula. Cada tamanho é uma peça:
+        se vender só uma, a peça sai do catálogo sozinha.
+        Deixe em branco para produtos sem tamanho, como bonés e carteiras.
+      placeholder: P, M, G
+
+  - type: input
+    id: size-note
+    attributes:
+      label: "Observação de tamanho"
+      description: |
+        Use no lugar de Tamanhos quando não for uma lista.
+        Por exemplo: Tamanho único, Consultar, 37 ao 44.
+      placeholder: Tamanho único
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Descrição"
+      description: Detalhes que aparecem no cartão do produto
+      placeholder: "Camiseta Dry Fit, Cor: Preta"
+
+  - type: textarea
+    id: photos
+    attributes:
+      label: "Fotos"
+      description: |
+        Arraste a foto para cá, ou toque para escolher da galeria.
+        Pode enviar duas: a primeira é a frente e a segunda o verso.
+    validations:
+      required: true

--- a/.github/workflows/add-product.yml
+++ b/.github/workflows/add-product.yml
@@ -1,0 +1,116 @@
+name: Add product from issue
+
+# The non-developer authoring path (CON-8). The owner files an issue from the
+# template, drags in a photo, and this opens a PR with the catalog change.
+#
+# This is the first write path in the repository driven by external input, so the
+# controls are deliberate:
+#  - the author is checked against an allow-list before anything is read;
+#  - every value is passed through the environment, never interpolated into a
+#    `run:` script, so nothing in an issue body can become shell;
+#  - all logic lives in tools/authoring/add-product.js, which is unit-tested
+#    against adversarial bodies — a workflow cannot be;
+#  - a PR is opened rather than committing to main, so the build gate and a human
+#    both run before anything ships;
+#  - third-party actions are pinned to a commit SHA.
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+# Least privilege. `contents` to push the branch, `pull-requests` to open the PR,
+# `issues` to report back on the issue.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+# One run per issue; a rapid edit supersedes the run it interrupted.
+concurrency:
+  group: add-product-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  add:
+    if: contains(github.event.issue.labels.*.name, 'novo-produto')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The issue body reaches the script only through the environment. It is
+      # never interpolated into a shell command, which is what stops a body
+      # containing backticks or $() from executing.
+      - name: Build the catalog change
+        id: build
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ALLOWED_AUTHORS: ${{ vars.PRODUCT_AUTHORS }}
+        run: node tools/authoring/add-product.js > "$RUNNER_TEMP/result.md"
+        continue-on-error: true
+
+      # The same gate a hand-written PR faces: schema, registries, image
+      # conventions, id uniqueness.
+      - name: Validate the catalog
+        id: validate
+        if: steps.build.outcome == 'success'
+        run: npm run build
+        continue-on-error: true
+
+      - name: Report a rejection back to the issue
+        if: steps.build.outcome != 'success' || steps.validate.outcome != 'success'
+        env:
+          # gh reads its token from GH_TOKEN.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          STAGE: ${{ steps.build.outcome != 'success' && 'form' || 'catalog' }}
+        run: |
+          {
+            echo "O produto não pôde ser adicionado."
+            echo
+            if [ "$STAGE" = "form" ]; then
+              cat "$RUNNER_TEMP/result.md"
+            else
+              echo "O formulário está correto, mas a validação do catálogo falhou."
+              echo "Veja o log da execução para os detalhes."
+            fi
+            echo
+            echo "Corrija e edite a issue — isso executa a verificação de novo."
+          } > "$RUNNER_TEMP/comment.md"
+          gh issue comment "$ISSUE_NUMBER" --body-file "$RUNNER_TEMP/comment.md"
+          exit 1
+
+      - name: Open the pull request
+        if: steps.build.outcome == 'success' && steps.validate.outcome == 'success'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          branch: add-product/issue-${{ github.event.issue.number }}
+          base: main
+          title: 'Novo produto: ${{ steps.build.outputs.product_id }} (${{ steps.build.outputs.category }})'
+          commit-message: |
+            feat: add product [${{ steps.build.outputs.product_id }}]
+
+            From issue #${{ github.event.issue.number }}, filed by
+            @${{ github.event.issue.user.login }}.
+          body: |
+            Gerado a partir da issue #${{ github.event.issue.number }}.
+
+            - Produto: `[${{ steps.build.outputs.product_id }}]`
+            - Categoria: `${{ steps.build.outputs.category }}`
+
+            A validação do catálogo passou. Revise a foto e os dados antes de aprovar.
+
+            Closes #${{ github.event.issue.number }}
+          labels: novo-produto
+          delete-branch: true

--- a/.github/workflows/edit-product.yml
+++ b/.github/workflows/edit-product.yml
@@ -1,0 +1,93 @@
+name: Edit product
+
+# The other half of CON-8 (option 6-C). An Issue Form is the right shape for
+# *adding* a product, because that needs a photo and only the issue editor can
+# accept an upload from a phone. Editing needs no photo, so a workflow_dispatch
+# form is simpler and faster: pick the product, change the price or mark a size
+# sold, and this opens a PR.
+#
+# Same controls as add-product: the actor is checked, every value reaches the
+# script through the environment, the catalog gate runs, and a PR is opened
+# rather than committing to main.
+
+on:
+  workflow_dispatch:
+    inputs:
+      product_id:
+        description: 'Código do produto, 10 dígitos (por exemplo 2307251157)'
+        required: true
+        type: string
+      price:
+        description: 'Novo preço, em reais. Deixe em branco para não mudar'
+        required: false
+        type: string
+      old_price:
+        description: 'Novo preço antigo. Escreva "remover" para tirar o desconto'
+        required: false
+        type: string
+      sold_out_sizes:
+        description: 'Tamanhos esgotados, separados por vírgula. Escreva "nenhum" para liberar todos'
+        required: false
+        type: string
+      description:
+        description: 'Nova descrição. Escreva "remover" para apagar'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: edit-product-${{ inputs.product_id }}
+  cancel-in-progress: false
+
+jobs:
+  edit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply the edit
+        id: edit
+        env:
+          PRODUCT_ID: ${{ inputs.product_id }}
+          NEW_PRICE: ${{ inputs.price }}
+          NEW_OLD_PRICE: ${{ inputs.old_price }}
+          SOLD_OUT_SIZES: ${{ inputs.sold_out_sizes }}
+          NEW_DESCRIPTION: ${{ inputs.description }}
+          ACTOR: ${{ github.actor }}
+          ALLOWED_AUTHORS: ${{ vars.PRODUCT_AUTHORS }}
+        run: node tools/authoring/edit-product.js
+
+      - name: Validate the catalog
+        run: npm run build
+
+      - name: Open the pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          branch: edit-product/${{ inputs.product_id }}
+          base: main
+          title: 'Atualiza produto [${{ inputs.product_id }}]'
+          commit-message: |
+            chore: update product [${{ inputs.product_id }}]
+
+            Applied by @${{ github.actor }} via the edit-product workflow.
+          body: |
+            Alterações no produto `[${{ inputs.product_id }}]`:
+
+            ${{ steps.edit.outputs.summary }}
+
+            A validação do catálogo passou.
+          delete-branch: true

--- a/docs/architecture/product-image-storage-plan.md
+++ b/docs/architecture/product-image-storage-plan.md
@@ -1161,8 +1161,9 @@ text entering `<meta content="...">` and JSON-LD needs JSON-string escaping, not
 | 3 Registries (+ rule 4a) | 2–3 d | high | Wave 1 | **done** |
 | 5a Image cache + drop originals | 1–1.5 d | high | — | **done** |
 | 4 Product schema v2 (+ rule 4b) | 3–3.5 d | high | Waves 1–3 | **done** |
-| 5b Runtime v2 + per-size availability + ladder | 2.5–3.5 d | medium | Wave 4 | next |
-| 6 Non-dev authoring | 3–4 d | **goal (CON-8)** | Waves 1–4 | ready |
+| 5b-i Runtime v2 + per-size availability | 1.5 d | medium | Wave 4 | **done** |
+| 5b-ii Delivery ladder + hashing | 1–2 d | low | Wave 4 | deferred — see note |
+| 6 Non-dev authoring | 3–4 d | **goal (CON-8)** | Waves 1–4 | **done** |
 | 7 Deep links + SEO | 2.5 d | medium (CON-11) | Wave 4 | ready |
 
 **Total ≈ 17–19 days.** No wave is blocked on an unanswered question.
@@ -1193,6 +1194,35 @@ into `index.html` as a committed JSON literal, and the build fails when that blo
 `readCategoryDictKeys` — the brace-matching scraper that recovered category names from a JavaScript
 literal — is deleted, and `underwear-man-subcategory` is renamed to `underwear-man` with an alias
 keeping old links alive. Suite: 207 tests.
+
+Wave 6 delivered CON-8, the goal the previous five waves were prerequisites for. A generated Issue Form
+(`.github/ISSUE_TEMPLATE/add-product.yml`, 64 dropdown options straight from the registries) plus
+`add-product.yml` opens a PR from a filed issue; `edit-product.yml` handles price, discount, description
+and per-size sold-out through a `workflow_dispatch` form. $0, nothing outside GitHub, no secret beyond
+`GITHUB_TOKEN`. The build fails when the form is stale, which is the closure that keeps the registries
+load-bearing. `docs/guides/adding-a-product.md` is written for the seller, not for a developer.
+
+**The architecture is thin-workflow, thick-tested-script.** A workflow cannot be unit-tested, so it does
+nothing but pass inputs through the environment and open a PR. Everything that can be wrong — parsing,
+validation, id allocation, path construction, the author check, the image decode — lives in
+`tools/lib/authoring.js` and `tools/authoring/`, with 124 tests including the adversarial cases the plan
+asked for: `../` in a category and in a brand, a nav group as a category, an off-GitHub photo host, an
+oversized upload whose `content-length` lies, a payload that is not an image, a same-minute double
+submission, and a duplicated size.
+
+Two notes for whoever picks this up. **`PRODUCT_AUTHORS` must be set** as a repository variable before
+the workflows accept anything — with it unset, every submission is refused, which is the correct
+default but looks like a broken robot. And **the workflows themselves are unverified**: they cannot run
+outside GitHub, so the end-to-end proof here is a dry run of the real script against a real
+GitHub-shaped issue body, not a real Actions run. The first live submission is the test.
+
+Wave 5b was split. **5b-i** (runtime reads v2, per-size availability, `sizeNote` rendered as a note) is
+done. **5b-ii** (400/800/1200 ladder, AVIF, content-hashed names) is **deferred rather than dropped**:
+measured, AVIF is 31% smaller than WebP but 6× slower to encode, and the full ladder takes `dist/` from
+~32 MB to roughly 77 MB because it holds every variant. That is the right trade in principle — build
+artifact up, per-visitor bytes down — but it is the weakest ratio left in the plan, and the ladder's real
+defect fix (cards serve a 400px image into a 400 CSS px slot, so they are soft on every retina phone) can
+be had from the 800px tier alone without AVIF.
 
 Wave 5a replaced the mtime freshness rule with a content-hash cache (`.image-cache/manifest.json`,
 cached in CI alongside `dist/images`), dropped `copyOriginals` in favour of a generated 1200 px JPEG

--- a/docs/guides/adding-a-product.md
+++ b/docs/guides/adding-a-product.md
@@ -1,0 +1,98 @@
+# Como adicionar um produto
+
+Você não precisa mexer em código. Tudo é feito pelo site do GitHub, do celular ou
+do computador.
+
+## Adicionar um produto novo
+
+1. Abra [**Issues → New issue**](../../issues/new/choose) e escolha
+   **Adicionar produto**.
+2. Preencha o formulário:
+
+   | Campo | O que colocar |
+   |---|---|
+   | **Categoria** | Onde o produto aparece no catálogo. A lista já vem pronta |
+   | **Marca** | A marca do produto, ou **Sem marca** |
+   | **Modelo** | A linha do produto, quando houver: `Shox`, `Campus`. Pode deixar em branco |
+   | **Preço** | O preço de venda: `89,90` |
+   | **Preço antigo** | Só se estiver com desconto. Precisa ser **maior** que o preço |
+   | **Tamanhos** | Os tamanhos disponíveis, separados por vírgula: `P, M, G` |
+   | **Observação de tamanho** | No lugar de Tamanhos, quando não é uma lista: `Tamanho único`, `Consultar` |
+   | **Descrição** | O texto que aparece no cartão do produto |
+   | **Fotos** | Arraste a foto, ou toque para escolher da galeria |
+
+3. Clique em **Submit new issue**.
+4. Em um ou dois minutos, um robô responde:
+   - **deu tudo certo** — ele abre um *Pull Request* com a alteração. Revise a
+     foto e os dados e clique em **Merge**. O site atualiza sozinho em poucos
+     minutos.
+   - **faltou algo** — ele comenta na issue dizendo exatamente o que corrigir.
+     Edite a issue e ele tenta de novo.
+
+### Sobre os tamanhos
+
+Cada tamanho é **uma peça**. Se você escreve `P, M, G`, o catálogo entende que
+existe uma peça de cada. Quando uma vende, só aquele tamanho sai de circulação —
+o produto continua no ar com os outros.
+
+Produtos sem tamanho, como bonés e carteiras, ficam com o campo **Tamanhos** em
+branco.
+
+### Sobre as fotos
+
+- Pode enviar **uma ou duas**. Com duas, a primeira é a frente e a segunda o
+  verso.
+- A foto é convertida automaticamente. Não precisa redimensionar nem renomear.
+- O nome do arquivo não importa: o sistema renomeia usando o código do produto.
+
+## Marcar um tamanho como esgotado
+
+Quando vender uma peça:
+
+1. Abra **Actions → Edit product → Run workflow**.
+2. Preencha:
+   - **Código do produto** — os 10 dígitos que aparecem no nome, por exemplo
+     `2307251157`
+   - **Tamanhos esgotados** — os tamanhos que acabaram: `M`. Para liberar todos
+     de novo, escreva `nenhum`
+3. Clique em **Run workflow**. Um Pull Request é aberto; revise e faça o merge.
+
+O mesmo formulário serve para mudar **preço**, **preço antigo** e **descrição**.
+Deixe em branco o que não quer mudar.
+
+> Os tamanhos esgotados são **substituídos**, não somados. Se `M` já estava
+> esgotado e você escreve `G`, o resultado é: `M` disponível e `G` esgotado. Para
+> ter os dois esgotados, escreva `M, G`.
+
+## Por que passa por Pull Request
+
+Nada vai para o site sem duas verificações:
+
+1. **Automática** — o catálogo é validado inteiro: preço, foto, categoria, código
+   único. Se algo estiver errado, o robô não abre o PR.
+2. **Sua** — você vê a foto e os dados antes de aprovar.
+
+É a mesma verificação que uma alteração feita por um desenvolvedor enfrenta.
+
+## Quando algo não funciona
+
+| O que aconteceu | O que fazer |
+|---|---|
+| O robô diz que você não tem permissão | Seu usuário precisa estar na variável `PRODUCT_AUTHORS` do repositório. Um desenvolvedor adiciona |
+| O robô diz que a categoria não existe | Escolha uma da lista. Categorias novas são criadas por um desenvolvedor |
+| O robô diz que a marca não existe | Escolha uma da lista, ou **Sem marca**. Marcas novas são adicionadas por um desenvolvedor |
+| O robô reclama do preço | Use vírgula ou ponto e no máximo dois decimais: `89,90` |
+| A foto não foi aceita | Envie de novo pelo campo **Fotos** da issue. Só fotos anexadas na própria issue são aceitas |
+
+## Para desenvolvedores
+
+- O formulário em `.github/ISSUE_TEMPLATE/add-product.yml` é **gerado** a partir
+  de `catalog/categories.json` e `catalog/brands.json`. Não edite à mão: rode
+  `node tools/sync-issue-form.js`. O build falha se estiver desatualizado.
+- Adicionar uma marca é uma linha em `catalog/brands.json` mais um
+  `node tools/sync-issue-form.js`.
+- A lógica está em `tools/lib/authoring.js` e `tools/authoring/`, com testes em
+  `tests/tools/authoring.test.js`, `add-product.test.js` e `edit-product.test.js`.
+  Os workflows só passam entradas e abrem o PR.
+- A permissão vem da variável de repositório `PRODUCT_AUTHORS`, uma lista de
+  usuários separada por vírgula.

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
   </main>
 
   <footer>
-    <p>Versão: 6.1.0 - 0.61.241</p>
+    <p>Versão: 6.2.0 - 0.61.241</p>
   </footer>
 
   <!-- registry:start -->

--- a/tests/footer/__snapshots__/footer.test.js.snap
+++ b/tests/footer/__snapshots__/footer.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Footer CSS and Markup renders footer markup as expected 1`] = `
 "<footer>
-    <p>Versão: 6.1.0 - 0.61.241</p>
+    <p>Versão: 6.2.0 - 0.61.241</p>
   </footer>"
 `;

--- a/tests/tools/add-product.test.js
+++ b/tests/tools/add-product.test.js
@@ -1,0 +1,260 @@
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const { checkAuthor, processIssue, reencode } = require('../../tools/authoring/add-product');
+
+const ROOT = path.join(__dirname, '../..');
+const PHOTO_URL = 'https://user-images.githubusercontent.com/1/photo.jpeg';
+const NOW = new Date('2026-08-22T14:35:00Z');
+
+const issueBody = (overrides = {}, photos = 1) => {
+  const fields = {
+    Categoria: 'Bonés Masculino',
+    Marca: 'Nike',
+    'Preço': '89,90',
+    Tamanhos: 'P, M',
+    'Descrição': 'Boné aba curva',
+    ...overrides,
+  };
+
+  const sections = Object.entries(fields)
+    .filter(([, value]) => value !== undefined)
+    .map(([label, value]) => `### ${label}\n\n${value}\n`);
+
+  const images = Array.from({ length: photos }, (_, i) => `![foto](${PHOTO_URL}?n=${i})`);
+  if (photos) sections.push(`### Fotos\n\n${images.join('\n')}\n`);
+
+  return sections.join('\n');
+};
+
+/** A real JPEG, so sharp has something genuine to decode. */
+const jpeg = (width = 900) =>
+  sharp({ create: { width, height: Math.round(width * 1.25), channels: 3, background: { r: 20, g: 90, b: 160 } } })
+    .jpeg()
+    .toBuffer();
+
+const respondWith = (bytes) => async () => ({
+  ok: true,
+  status: 200,
+  headers: { get: (name) => (name === 'content-length' ? String(bytes.length) : null) },
+  arrayBuffer: async () => bytes,
+});
+
+const run = async (overrides = {}, options = {}) =>
+  processIssue({
+    body: issueBody(overrides, options.photos === undefined ? 1 : options.photos),
+    author: 'owner',
+    allowedAuthors: 'owner,collaborator',
+    dryRun: true,
+    now: NOW,
+    fetchImpl: options.fetchImpl || respondWith(await jpeg()),
+  });
+
+describe('checkAuthor', () => {
+  // First, before the body is read: without it, any GitHub user could file an
+  // issue on a public repository and have the workflow commit for them.
+  it('accepts an allow-listed author, case-insensitively', () => {
+    expect(checkAuthor('Owner', 'owner,other')).toBeNull();
+  });
+
+  it('rejects an author who is not listed', () => {
+    expect(checkAuthor('stranger', 'owner')).toMatch(/not on the allow-list/);
+  });
+
+  it('rejects everything when the allow-list is empty', () => {
+    expect(checkAuthor('owner', '')).toMatch(/No allowed authors are configured/);
+    expect(checkAuthor('owner', undefined)).toMatch(/No allowed authors are configured/);
+  });
+
+  it('rejects a missing author', () => {
+    expect(checkAuthor('', 'owner')).toMatch(/no author/);
+  });
+});
+
+describe('reencode', () => {
+  // The upload is never stored as received: sharp either decodes it or throws,
+  // which turns "is this an image?" into a decode rather than a guess.
+  it('produces a JPEG from a JPEG', async () => {
+    const out = await reencode(await jpeg());
+    expect((await sharp(out).metadata()).format).toBe('jpeg');
+  });
+
+  it('caps the stored width', async () => {
+    const out = await reencode(await jpeg(3000));
+    expect((await sharp(out).metadata()).width).toBe(1600);
+  });
+
+  it('converts a PNG upload rather than storing it as-is', async () => {
+    const png = await sharp({ create: { width: 400, height: 400, channels: 3, background: '#fff' } })
+      .png()
+      .toBuffer();
+    expect((await sharp(await reencode(png)).metadata()).format).toBe('jpeg');
+  });
+
+  it('refuses a file that is not an image', async () => {
+    await expect(reencode(Buffer.from('#!/bin/sh\nrm -rf /\n'))).rejects.toThrow(/not an image/);
+  });
+});
+
+describe('processIssue', () => {
+  it('builds a product from a filled-in form', async () => {
+    const result = await run();
+    expect(result.errors).toBeUndefined();
+    expect(result.category).toBe('caps-man');
+    expect(result.product).toMatchObject({
+      brand: 'nike',
+      price: 89.9,
+      sizes: [{ size: 'P' }, { size: 'M' }],
+      description: 'Boné aba curva',
+    });
+    expect(result.imagePaths).toEqual([`images/man/caps/${result.product.id}-nike.jpeg`]);
+  });
+
+  it('allocates an id no product already uses', async () => {
+    const { product } = await run();
+    const existing = fs
+      .readdirSync(path.join(ROOT, 'products'))
+      .filter((file) => file.endsWith('.json'))
+      .flatMap((file) => JSON.parse(fs.readFileSync(path.join(ROOT, 'products', file), 'utf8')))
+      .map((entry) => entry.id);
+    expect(existing).not.toContain(product.id);
+  });
+
+  it('produces a product the catalog schema accepts', async () => {
+    const { compileProductSchema } = require('../../tools/lib/validate');
+    const { product } = await run();
+    expect(compileProductSchema()([product])).toBe(true);
+  });
+
+  it('names both files for a two-photo submission', async () => {
+    const result = await run({}, { photos: 2 });
+    expect(result.imagePaths).toEqual([
+      `images/man/caps/${result.product.id}-nike-front.jpeg`,
+      `images/man/caps/${result.product.id}-nike-back.jpeg`,
+    ]);
+  });
+
+  it('places an unbranded product outside any brand folder', async () => {
+    const result = await run({ Categoria: 'Tênis', Marca: 'Sem marca' });
+    expect(result.imagePaths[0]).toBe(`images/man/shoes/${result.product.id}.jpeg`);
+  });
+
+  describe('rejections', () => {
+    it('refuses an author who is not allow-listed', async () => {
+      const result = await processIssue({
+        body: issueBody(),
+        author: 'stranger',
+        allowedAuthors: 'owner',
+        dryRun: true,
+        now: NOW,
+        fetchImpl: respondWith(await jpeg()),
+      });
+      expect(result.errors[0]).toMatch(/not on the allow-list/);
+    });
+
+    it('refuses a submission with no photo', async () => {
+      const result = await run({}, { photos: 0 });
+      expect(result.errors).toContain('At least one photo is required.');
+    });
+
+    // A submitter could otherwise point the runner at any URL they like.
+    it('ignores a photo hosted somewhere other than GitHub', async () => {
+      const result = await processIssue({
+        body: `${issueBody({}, 0)}\n### Fotos\n\n![x](https://evil.example.com/p.jpeg)\n`,
+        author: 'owner',
+        allowedAuthors: 'owner',
+        dryRun: true,
+        now: NOW,
+        fetchImpl: respondWith(await jpeg()),
+      });
+      expect(result.errors).toContain('At least one photo is required.');
+    });
+
+    it('refuses an oversized photo even when content-length lies', async () => {
+      const huge = Buffer.alloc(13 * 1024 * 1024, 1);
+      const result = await run({}, {
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          headers: { get: () => '10' },
+          arrayBuffer: async () => huge,
+        }),
+      });
+      expect(result.errors[0]).toMatch(/larger than/);
+    });
+
+    it('reports a failed download rather than throwing', async () => {
+      const result = await run({}, {
+        fetchImpl: async () => ({ ok: false, status: 404, headers: { get: () => null }, arrayBuffer: async () => Buffer.alloc(0) }),
+      });
+      expect(result.errors[0]).toMatch(/HTTP 404/);
+    });
+
+    it('refuses a payload that is not an image', async () => {
+      const result = await run({}, { fetchImpl: respondWith(Buffer.from('not an image')) });
+      expect(result.errors[0]).toMatch(/not an image/);
+    });
+
+    it.each([
+      ['a crafted category', { Categoria: '../../../etc' }, /is not a category/],
+      ['a crafted brand', { Marca: '../../root' }, /is not in catalog\/brands\.json/],
+      ['a nav group', { Categoria: 'clothing-man-subcategory' }, /is not a category/],
+      ['an unparseable price', { 'Preço': 'de graça' }, /must be a positive number/],
+      ['a fake discount', { 'Preço antigo': '10,00' }, /must be higher than/],
+    ])('refuses %s', async (_label, overrides, expected) => {
+      const { errors } = await run(overrides);
+      expect(errors.some((error) => expected.test(error))).toBe(true);
+    });
+
+    it('reports every problem at once, so the seller is not sent round the loop', async () => {
+      const { errors } = await run({ Categoria: 'ghost', Marca: 'ghost', 'Preço': 'x' });
+      expect(errors.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  // Two issues filed in the same minute would collide on a clock-derived code,
+  // and a duplicate id is a build error.
+  it('gives two same-minute submissions different ids', async () => {
+    const { allocateId } = require('../../tools/lib/authoring');
+    const first = allocateId(new Set(), NOW);
+    const second = allocateId(new Set([first]), NOW);
+    expect(second).not.toBe(first);
+  });
+});
+
+describe('The generated issue form', () => {
+  const { FIELDS, TEMPLATE_PATH, renderIssueForm } = require('../../tools/lib/issue-form');
+  const { loadRegistry } = require('../../tools/lib/registry');
+
+  it('is committed and up to date', () => {
+    const committed = fs.readFileSync(path.join(ROOT, TEMPLATE_PATH), 'utf8');
+    expect(renderIssueForm(loadRegistry())).toBe(committed);
+  });
+
+  // The form and the parser agree on field labels only because both are pinned
+  // here; a renamed label in one would otherwise silently drop an answer.
+  it('labels every field the parser reads', () => {
+    const template = fs.readFileSync(path.join(ROOT, TEMPLATE_PATH), 'utf8');
+    Object.values(FIELDS).forEach((label) => {
+      expect(template).toContain(`label: "${label}"`);
+    });
+  });
+
+  it('offers every category and brand from the registries', () => {
+    const template = fs.readFileSync(path.join(ROOT, TEMPLATE_PATH), 'utf8');
+    const registry = loadRegistry();
+
+    registry.leaves.forEach((leaf) => expect(template).toContain(`- "${leaf.label}"`));
+    Object.entries(registry.brands)
+      .filter(([slug]) => slug !== 'unbranded')
+      .forEach(([, brand]) => expect(template).toContain(`- "${brand.label}"`));
+  });
+
+  it('does not offer a nav group as a category', () => {
+    const template = fs.readFileSync(path.join(ROOT, TEMPLATE_PATH), 'utf8');
+    loadRegistry().groups.forEach((group) => {
+      expect(template).not.toContain(`- "${group.navLabel}"\n`);
+    });
+  });
+});

--- a/tests/tools/authoring.test.js
+++ b/tests/tools/authoring.test.js
@@ -1,0 +1,369 @@
+const {
+  MAX_IMAGE_BYTES,
+  VARIANTS,
+  allocateId,
+  buildSubmission,
+  extractImageUrls,
+  imagePathFor,
+  isAllowedAttachmentUrl,
+  isSafeImagePath,
+  listedAtFrom,
+  parseIssueBody,
+  parsePrice,
+  parseSizes,
+} = require('../../tools/lib/authoring');
+
+const { loadRegistry } = require('../../tools/lib/registry');
+
+const registry = loadRegistry();
+const NOW = new Date('2026-08-22T14:35:00Z');
+
+const body = (fields) =>
+  Object.entries(fields)
+    .map(([label, value]) => `### ${label}\n\n${value}\n`)
+    .join('\n');
+
+const VALID_FIELDS = {
+  Categoria: 'caps-man',
+  Marca: 'nike',
+  'Preço': '89,90',
+  Tamanhos: 'P, M',
+  'Descrição': 'Boné aba curva',
+};
+
+const submit = (overrides = {}, options = {}) =>
+  buildSubmission({
+    fields: { ...VALID_FIELDS, ...overrides },
+    registry,
+    takenIds: new Set(),
+    now: NOW,
+    imageCount: 1,
+    ...options,
+  });
+
+describe('parseIssueBody', () => {
+  it('reads each field under its heading', () => {
+    expect(parseIssueBody(body({ Categoria: 'caps-man', Marca: 'nike' })))
+      .toEqual({ Categoria: 'caps-man', Marca: 'nike' });
+  });
+
+  it('omits a field GitHub marked as unanswered', () => {
+    expect(parseIssueBody('### Marca\n\n_No response_\n')).toEqual({});
+  });
+
+  it('keeps a multi-line answer', () => {
+    const fields = parseIssueBody('### Descrição\n\nlinha um\nlinha dois\n');
+    expect(fields['Descrição']).toBe('linha um\nlinha dois');
+  });
+
+  it('tolerates an empty body', () => {
+    expect(parseIssueBody('')).toEqual({});
+    expect(parseIssueBody(undefined)).toEqual({});
+  });
+
+  // A maintainer may tidy the issue by hand before the workflow runs.
+  it('tolerates extra blank lines and stray text before the first field', () => {
+    expect(parseIssueBody('olá\n\n### Marca\n\n\nnike\n\n\n')).toEqual({ Marca: 'nike' });
+  });
+});
+
+describe('parsePrice', () => {
+  it.each([
+    ['89,90', 89.9],
+    ['89.90', 89.9],
+    ['R$ 89,90', 89.9],
+    ['120', 120],
+  ])('reads %s', (raw, expected) => {
+    expect(parsePrice(raw)).toBe(expected);
+  });
+
+  // Guessing at a malformed price is worse than rejecting it.
+  it.each(['', 'grátis', '89,900', '-5', '0', '1.2.3', '89,9,9'])('rejects %s', (raw) => {
+    expect(parsePrice(raw)).toBeNull();
+  });
+});
+
+describe('parseSizes', () => {
+  it('splits a multi-select answer into units', () => {
+    expect(parseSizes('P, M, G')).toEqual({ sizes: [{ size: 'P' }, { size: 'M' }, { size: 'G' }] });
+  });
+
+  it('returns no units for a blank answer', () => {
+    expect(parseSizes('')).toEqual({ sizes: [] });
+    expect(parseSizes(undefined)).toEqual({ sizes: [] });
+  });
+
+  // Two units of the same size is a stock question the form cannot express, so
+  // it is asked rather than assumed.
+  it('rejects a duplicated size', () => {
+    expect(parseSizes('M, M').error).toMatch(/listed twice/);
+  });
+});
+
+describe('allocateId', () => {
+  it('uses the current minute when it is free', () => {
+    expect(allocateId(new Set(), NOW)).toBe('2208261435');
+  });
+
+  it('derives a listedAt that agrees with the id', () => {
+    expect(listedAtFrom(allocateId(new Set(), NOW))).toBe('2026-08-22T14:35:00Z');
+  });
+
+  // The reason this exists: the code has minute granularity, so a clock alone
+  // collides for two submissions in the same minute — and a collision is a build
+  // error, not a warning.
+  it('steps forward past a taken minute', () => {
+    expect(allocateId(new Set(['2208261435']), NOW)).toBe('2208261436');
+  });
+
+  it('steps past a run of taken minutes', () => {
+    const taken = new Set(['2208261435', '2208261436', '2208261437']);
+    expect(allocateId(taken, NOW)).toBe('2208261438');
+  });
+
+  it('never returns an id already in the catalog', () => {
+    const taken = new Set();
+    for (let i = 0; i < 50; i += 1) taken.add(allocateId(taken, NOW));
+    expect(taken.size).toBe(50);
+  });
+
+  it('gives up rather than spinning when everything is taken', () => {
+    const taken = new Set();
+    for (let i = 0; i < 60 * 24; i += 1) {
+      taken.add(allocateId(new Set([...taken]), NOW));
+    }
+    expect(() => allocateId(taken, NOW)).toThrow(/could not allocate/);
+  });
+});
+
+describe('imagePathFor', () => {
+  const flat = registry.bySlug.get('caps-man');
+  const branded = registry.bySlug.get('shoes-man');
+
+  it('places a flat category image directly in its directory', () => {
+    expect(imagePathFor(flat, 'nike', '2208261435'))
+      .toBe('images/man/caps/2208261435-nike.jpeg');
+  });
+
+  it('places a branded product inside its brand folder', () => {
+    expect(imagePathFor(branded, 'nike', '2208261435'))
+      .toBe('images/man/shoes/nike/2208261435-nike.jpeg');
+  });
+
+  // Matching validator rule 4a: an unbranded product has no folder to sit in.
+  it('keeps an unbranded product out of a brand folder', () => {
+    expect(imagePathFor(branded, 'unbranded', '2208261435'))
+      .toBe('images/man/shoes/2208261435.jpeg');
+  });
+
+  it('adds the variant suffix for a two-photo product', () => {
+    expect(imagePathFor(flat, 'nike', '2208261435', 'front'))
+      .toBe('images/man/caps/2208261435-nike-front.jpeg');
+  });
+
+  it('refuses an unknown variant', () => {
+    expect(() => imagePathFor(flat, 'nike', '2208261435', 'side')).toThrow(/unknown image variant/);
+  });
+});
+
+describe('buildSubmission', () => {
+  it('builds a valid product', () => {
+    const result = submit();
+    expect(result.errors).toBeUndefined();
+    expect(result.category).toBe('caps-man');
+    expect(result.product).toEqual({
+      id: '2208261435',
+      brand: 'nike',
+      price: 89.9,
+      sizes: [{ size: 'P' }, { size: 'M' }],
+      description: 'Boné aba curva',
+      images: ['images/man/caps/2208261435-nike.jpeg'],
+      listedAt: '2026-08-22T14:35:00Z',
+    });
+  });
+
+  it('produces a product the catalog schema accepts', () => {
+    const { compileProductSchema } = require('../../tools/lib/validate');
+    const matches = compileProductSchema();
+    expect(matches([submit().product])).toBe(true);
+  });
+
+  it('names both files for a two-photo product', () => {
+    expect(submit({}, { imageCount: 2 }).imagePaths).toEqual([
+      'images/man/caps/2208261435-nike-front.jpeg',
+      'images/man/caps/2208261435-nike-back.jpeg',
+    ]);
+  });
+
+  it('defaults a blank brand to unbranded', () => {
+    expect(submit({ Marca: undefined }).product.brand).toBe('unbranded');
+  });
+
+  it('carries a size note when there are no sizes', () => {
+    const result = submit({ Tamanhos: undefined, 'Observação de tamanho': 'Consultar' });
+    expect(result.product.sizes).toEqual([]);
+    expect(result.product.sizeNote).toBe('Consultar');
+  });
+
+  it('omits optional fields rather than emitting sentinels', () => {
+    const product = submit({ 'Descrição': undefined }).product;
+    expect('description' in product).toBe(false);
+    expect('oldPrice' in product).toBe(false);
+    expect('model' in product).toBe(false);
+  });
+
+  it('accepts a genuine discount', () => {
+    expect(submit({ 'Preço antigo': '129,90' }).product.oldPrice).toBe(129.9);
+  });
+
+  describe('rejections', () => {
+    it.each([
+      ['a missing category', { Categoria: undefined }, /Categoria is required/],
+      ['an unknown category', { Categoria: 'ghost-man' }, /is not a category/],
+      // A nav group is not selectable and has no products file.
+      ['a nav group as the category', { Categoria: 'clothing-man-subcategory' }, /is not a category/],
+      ['an unknown brand', { Marca: 'ghostbrand' }, /is not in catalog\/brands\.json/],
+      ['a missing price', { 'Preço': undefined }, /Preço must be a positive number/],
+      ['a discount that is not one', { 'Preço antigo': '10,00' }, /must be higher than/],
+      ['both sizes and a note', { 'Observação de tamanho': 'Consultar' }, /not both/],
+      ['a redundant N\\/A note', { Tamanhos: undefined, 'Observação de tamanho': 'N/A' }, /redundant/],
+      ['a duplicated size', { Tamanhos: 'M, M' }, /listed twice/],
+    ])('rejects %s', (_label, overrides, expected) => {
+      const { errors } = submit(overrides);
+      expect(errors.some((error) => expected.test(error))).toBe(true);
+    });
+
+    it('rejects a submission with no photo', () => {
+      expect(submit({}, { imageCount: 0 }).errors).toContain('At least one photo is required.');
+    });
+
+    it('rejects more photos than the variant vocabulary supports', () => {
+      expect(submit({}, { imageCount: 3 }).errors.some((e) => /At most 2 photos/.test(e))).toBe(true);
+    });
+
+    // All of them at once, so the submitter is not sent round the loop repeatedly.
+    it('reports every problem in one pass', () => {
+      const { errors } = submit({ Categoria: 'ghost', Marca: 'ghost', 'Preço': 'grátis' });
+      expect(errors.length).toBeGreaterThanOrEqual(3);
+    });
+
+    // A path traversal cannot get through, because the path is composed from
+    // registry values and the allocated id rather than from anything submitted.
+    it('cannot be steered outside images/ by a crafted category', () => {
+      const { errors } = submit({ Categoria: '../../etc/passwd' });
+      expect(errors.some((error) => /is not a category/.test(error))).toBe(true);
+    });
+
+    it('cannot be steered outside images/ by a crafted brand', () => {
+      const { errors } = submit({ Marca: '../../../root' });
+      expect(errors.some((error) => /is not in catalog\/brands\.json/.test(error))).toBe(true);
+    });
+  });
+});
+
+describe('extractImageUrls', () => {
+  const ok = 'https://user-images.githubusercontent.com/1/photo.jpeg';
+
+  it('reads a markdown image', () => {
+    expect(extractImageUrls(`![foto](${ok})`)).toEqual([ok]);
+  });
+
+  it('reads an html image', () => {
+    expect(extractImageUrls(`<img src="${ok}" width="300">`)).toEqual([ok]);
+  });
+
+  it('keeps upload order and de-duplicates', () => {
+    const second = 'https://github.com/o/r/assets/1/b.jpeg';
+    expect(extractImageUrls(`![a](${ok})\n![a](${ok})\n![b](${second})`)).toEqual([ok, second]);
+  });
+
+  // Otherwise a submitter could make the runner fetch any URL they like.
+  it.each([
+    'https://evil.example.com/payload.jpeg',
+    'http://user-images.githubusercontent.com/1/x.jpeg',
+    'file:///etc/passwd',
+    'https://user-images.githubusercontent.com.evil.example.com/x.jpeg',
+  ])('ignores %s', (url) => {
+    expect(extractImageUrls(`![x](${url})`)).toEqual([]);
+    expect(isAllowedAttachmentUrl(url)).toBe(false);
+  });
+
+  it('ignores a body with no images', () => {
+    expect(extractImageUrls('### Marca\n\nnike')).toEqual([]);
+  });
+});
+
+describe('isSafeImagePath', () => {
+  it('accepts a composed catalog path', () => {
+    expect(isSafeImagePath('images/man/caps/2208261435-nike.jpeg')).toBe(true);
+  });
+
+  it.each([
+    '../secrets.jpeg',
+    'images/../../etc/passwd',
+    '/etc/passwd',
+    'C:/windows/system32',
+    'products/all.json',
+    'images/./x.jpeg',
+    '',
+  ])('rejects %s', (candidate) => {
+    expect(isSafeImagePath(candidate)).toBe(false);
+  });
+
+  it('rejects a null byte', () => {
+    expect(isSafeImagePath('images/x\0.jpeg')).toBe(false);
+  });
+});
+
+describe('Constants', () => {
+  it('caps the upload size', () => {
+    expect(MAX_IMAGE_BYTES).toBe(12 * 1024 * 1024);
+  });
+
+  it('uses the same variant vocabulary as the validator', () => {
+    const { IMAGE_VARIANTS } = require('../../tools/lib/validate');
+    expect(VARIANTS.slice().sort()).toEqual([...IMAGE_VARIANTS].sort());
+  });
+});
+
+describe('Resolving by label or slug', () => {
+  const { NO_BRAND_OPTION, resolveBrand, resolveLeaf } = require('../../tools/lib/authoring');
+
+  it('resolves a category by its human label, which is what the form shows', () => {
+    expect(resolveLeaf(registry, 'Bonés Masculino').slug).toBe('caps-man');
+  });
+
+  it('resolves a category by slug, for an issue edited by hand', () => {
+    expect(resolveLeaf(registry, 'caps-man').slug).toBe('caps-man');
+  });
+
+  it('refuses a nav group by either name', () => {
+    expect(resolveLeaf(registry, 'clothing-man-subcategory')).toBeNull();
+    expect(resolveLeaf(registry, 'Moda')).toBeNull();
+  });
+
+  it('resolves a brand by label and by slug', () => {
+    expect(resolveBrand(registry, 'Tommy Hilfiger')).toBe('tommy-hilfiger');
+    expect(resolveBrand(registry, 'tommy-hilfiger')).toBe('tommy-hilfiger');
+  });
+
+  // `unbranded` has an empty label, so the form offers a readable sentinel.
+  it('maps the no-brand option to unbranded', () => {
+    expect(resolveBrand(registry, NO_BRAND_OPTION)).toBe('unbranded');
+  });
+
+  it('does not resolve the empty label to unbranded by accident', () => {
+    expect(resolveBrand(registry, '')).toBeNull();
+  });
+
+  it('refuses an unknown brand', () => {
+    expect(resolveBrand(registry, 'Ghostbrand')).toBeNull();
+  });
+
+  it('accepts a submission that used labels throughout', () => {
+    const result = submit({ Categoria: 'Bonés Masculino', Marca: 'Nike' });
+    expect(result.errors).toBeUndefined();
+    expect(result.category).toBe('caps-man');
+    expect(result.product.brand).toBe('nike');
+  });
+});

--- a/tests/tools/edit-product.test.js
+++ b/tests/tools/edit-product.test.js
@@ -1,0 +1,106 @@
+const { applyEdit, locate } = require('../../tools/authoring/edit-product');
+
+const product = (overrides = {}) => ({
+  id: '2307251157',
+  brand: 'gucci',
+  price: 89.9,
+  sizes: [{ size: 'M' }, { size: 'G' }],
+  images: ['images/man/belts/2307251157-gucci.jpeg'],
+  listedAt: '2025-07-23T11:57:00Z',
+  ...overrides,
+});
+
+const edit = (inputs, overrides) => {
+  const target = product(overrides);
+  const result = applyEdit(target, inputs);
+  return { ...result, product: target };
+};
+
+describe('locate', () => {
+  it('finds a real product and its category', () => {
+    const found = locate('2307251157');
+    expect(found).not.toBeNull();
+    expect(found.products[found.index].id).toBe('2307251157');
+  });
+
+  it('returns null for an unknown code', () => {
+    expect(locate('0000000000')).toBeNull();
+  });
+});
+
+describe('applyEdit', () => {
+  it('updates the price', () => {
+    const { changes, product: after } = edit({ price: '99,90' });
+    expect(after.price).toBe(99.9);
+    expect(changes[0]).toMatch(/preço/);
+  });
+
+  it('rejects an unparseable price', () => {
+    expect(edit({ price: 'de graça' }).errors[0]).toMatch(/not a valid price/);
+  });
+
+  it('adds a discount and refuses one that is not a discount', () => {
+    expect(edit({ oldPrice: '129,90' }).product.oldPrice).toBe(129.9);
+    expect(edit({ oldPrice: '10,00' }).errors[0]).toMatch(/must be higher/);
+  });
+
+  it('clears a discount on request', () => {
+    const { product: after } = edit({ oldPrice: 'remover' }, { oldPrice: 129.9 });
+    expect('oldPrice' in after).toBe(false);
+  });
+
+  it('clears a description on request', () => {
+    const { product: after } = edit({ description: 'REMOVER' }, { description: 'antigo' });
+    expect('description' in after).toBe(false);
+  });
+
+  // The edit the seller will reach for most: one size goes, the row keeps selling.
+  it('marks a single size sold out and leaves the rest available', () => {
+    const { product: after } = edit({ soldOutSizes: 'M' });
+    expect(after.sizes).toEqual([{ size: 'M', soldOut: true }, { size: 'G' }]);
+    expect('soldOut' in after).toBe(false);
+  });
+
+  it('replaces the sold-out set rather than adding to it', () => {
+    const { product: after } = edit({ soldOutSizes: 'G' }, {
+      sizes: [{ size: 'M', soldOut: true }, { size: 'G' }],
+    });
+    expect(after.sizes).toEqual([{ size: 'M' }, { size: 'G', soldOut: true }]);
+  });
+
+  it('puts every size back on sale', () => {
+    const { product: after } = edit({ soldOutSizes: 'nenhum' }, {
+      sizes: [{ size: 'M', soldOut: true }, { size: 'G', soldOut: true }],
+    });
+    expect(after.sizes).toEqual([{ size: 'M' }, { size: 'G' }]);
+  });
+
+  it('refuses a size the product does not have', () => {
+    expect(edit({ soldOutSizes: 'XG' }).errors[0]).toMatch(/has no size XG/);
+  });
+
+  // A row with no units carries the flag itself, so there is no size to name.
+  it('puts a sizeless product back on sale', () => {
+    const { product: after } = edit({ soldOutSizes: 'nenhum' }, { sizes: [], soldOut: true });
+    expect('soldOut' in after).toBe(false);
+  });
+
+  it('refuses a size list for a sizeless product', () => {
+    expect(edit({ soldOutSizes: 'M' }, { sizes: [] }).errors[0]).toMatch(/has no sizes/);
+  });
+
+  it('refuses an edit that changes nothing', () => {
+    expect(edit({}).errors[0]).toMatch(/Nothing to change/);
+  });
+
+  it('applies several changes at once', () => {
+    const { changes } = edit({ price: '79,90', soldOutSizes: 'G', description: 'novo' });
+    expect(changes).toHaveLength(3);
+  });
+
+  it('leaves the product valid against the schema', () => {
+    const { compileProductSchema } = require('../../tools/lib/validate');
+    const { product: after } = edit({ price: '79,90', soldOutSizes: 'M' });
+    expect(compileProductSchema()([after])).toBe(true);
+  });
+});

--- a/tools/authoring/add-product.js
+++ b/tools/authoring/add-product.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Turns an "add a product" issue into a catalog change.
+ *
+ * The workflow does nothing but pass inputs in and open a PR with whatever this
+ * writes; all the logic lives here and in tools/lib/authoring.js so it can be
+ * tested. Run it directly to dry-run an issue body:
+ *
+ *   ISSUE_BODY="$(cat body.md)" ISSUE_AUTHOR=someone \
+ *   ALLOWED_AUTHORS=owner node tools/authoring/add-product.js --dry-run
+ *
+ * Every input is untrusted. The controls that matter:
+ *  - the author is checked against an allow-list before anything is read;
+ *  - the category and brand are resolved against the registries, never used as
+ *    given, so a path cannot be steered out of images/;
+ *  - the image is fetched only from a GitHub attachment host, size-capped, and
+ *    re-encoded through sharp rather than trusted as a JPEG;
+ *  - the product file is parsed and re-serialised, never string-concatenated.
+ */
+
+const fsp = require('fs/promises');
+const path = require('path');
+const sharp = require('sharp');
+
+const {
+  MAX_IMAGE_BYTES,
+  buildSubmission,
+  extractImageUrls,
+  isSafeImagePath,
+  parseIssueBody,
+} = require('../lib/authoring');
+const { listCategories, readCategory } = require('../lib/catalog');
+const { loadRegistry } = require('../lib/registry');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PRODUCTS_DIR = path.join(ROOT, 'products');
+
+// Re-encode ceiling. Wider than the 1200px derivative so the source keeps some
+// headroom, but bounded so a huge upload cannot land in the repository.
+const MAX_STORED_WIDTH = 1600;
+const STORED_QUALITY = 86;
+
+/**
+ * Checks the issue author against the allow-list.
+ *
+ * First, before the body is even parsed. Without this, any GitHub user could
+ * file an issue on a public repository and have the workflow commit for them.
+ * @param {string} author The issue author's login.
+ * @param {string} allowed Comma-separated allow-list.
+ * @returns {string|null} An error message, or null when the author is allowed.
+ */
+const checkAuthor = (author, allowed) => {
+  const permitted = String(allowed || '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!permitted.length) return 'No allowed authors are configured, so nothing can be accepted.';
+  if (!author) return 'The issue has no author.';
+  return permitted.includes(String(author).toLowerCase())
+    ? null
+    : `@${author} is not on the allow-list for adding products.`;
+};
+
+/**
+ * Downloads an attachment, refusing anything oversized.
+ * @param {string} url Attachment URL, already host-checked.
+ * @param {Function} fetchImpl Injected for tests.
+ * @returns {Promise<Buffer>} The downloaded bytes.
+ */
+const download = async (url, fetchImpl) => {
+  const response = await fetchImpl(url);
+  if (!response.ok) throw new Error(`could not download the photo (HTTP ${response.status})`);
+
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) {
+    throw new Error(`the photo is larger than ${MAX_IMAGE_BYTES} bytes`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  // Checked again after the fact: content-length is a claim, not a guarantee.
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(`the photo is larger than ${MAX_IMAGE_BYTES} bytes`);
+  }
+  return bytes;
+};
+
+/**
+ * Re-encodes an upload as a JPEG.
+ *
+ * The upload is never stored as received. sharp either produces a JPEG or
+ * throws, which turns "is this really an image?" into a decode step rather than
+ * a guess about a filename.
+ * @param {Buffer} bytes Downloaded bytes.
+ * @returns {Promise<Buffer>} A JPEG.
+ */
+const reencode = async (bytes) => {
+  try {
+    return await sharp(bytes)
+      .rotate()
+      .resize({ width: MAX_STORED_WIDTH, withoutEnlargement: true })
+      .jpeg({ quality: STORED_QUALITY, progressive: true, mozjpeg: true })
+      .toBuffer();
+  } catch (error) {
+    throw new Error(`the uploaded file is not an image sharp can decode: ${error.message}`);
+  }
+};
+
+/**
+ * Inserts a product into its category file, newest first.
+ *
+ * Parsed and re-serialised rather than appended textually, so a crafted value
+ * cannot break out of the JSON.
+ * @param {string} category Category slug.
+ * @param {object} product The product to add.
+ * @returns {Promise<number>} The resulting product count.
+ */
+const insertProduct = async (category, product) => {
+  const file = path.join(PRODUCTS_DIR, `${category}.json`);
+  const products = readCategory(PRODUCTS_DIR, category);
+
+  products.unshift(product);
+  products.sort((a, b) => Date.parse(b.listedAt) - Date.parse(a.listedAt));
+
+  await fsp.writeFile(file, `${JSON.stringify(products, null, 4)}\n`, 'utf8');
+  return products.length;
+};
+
+/**
+ * Collects every id already in use, so the allocator cannot reuse one.
+ * @returns {Set<string>} Ids in use.
+ */
+const takenIds = () => {
+  const ids = new Set();
+  for (const category of listCategories(PRODUCTS_DIR)) {
+    for (const product of readCategory(PRODUCTS_DIR, category)) ids.add(product.id);
+  }
+  return ids;
+};
+
+/**
+ * Processes one issue into a catalog change.
+ * @param {object} options Inputs.
+ * @param {string} options.body Issue body.
+ * @param {string} options.author Issue author login.
+ * @param {string} options.allowedAuthors Comma-separated allow-list.
+ * @param {boolean} [options.dryRun] Skip writing.
+ * @param {Date} [options.now] Current time.
+ * @param {Function} [options.fetchImpl] Injected fetch.
+ * @returns {Promise<object>} Either { errors } or a summary of what was written.
+ */
+const processIssue = async ({
+  body,
+  author,
+  allowedAuthors,
+  dryRun = false,
+  now = new Date(),
+  fetchImpl = fetch,
+}) => {
+  const authorError = checkAuthor(author, allowedAuthors);
+  if (authorError) return { errors: [authorError] };
+
+  const registry = loadRegistry();
+  const fields = parseIssueBody(body);
+  const urls = extractImageUrls(body);
+
+  const submission = buildSubmission({
+    fields,
+    registry,
+    takenIds: takenIds(),
+    now,
+    imageCount: urls.length,
+  });
+  if (submission.errors) return { errors: submission.errors };
+
+  const { product, category, imagePaths } = submission;
+
+  // Should be unreachable: every path is composed from registry values. Checked
+  // because the cost of being wrong is a write outside the repository.
+  const unsafe = imagePaths.filter((relative) => !isSafeImagePath(relative));
+  if (unsafe.length) return { errors: [`refusing to write outside images/: ${unsafe.join(', ')}`] };
+
+  const images = [];
+  for (const [index, url] of urls.entries()) {
+    try {
+      images.push({ relative: imagePaths[index], bytes: await reencode(await download(url, fetchImpl)) });
+    } catch (error) {
+      return { errors: [error.message] };
+    }
+  }
+
+  if (dryRun) {
+    return { product, category, imagePaths, dryRun: true, bytes: images.map((image) => image.bytes.length) };
+  }
+
+  for (const image of images) {
+    const target = path.join(ROOT, image.relative);
+    await fsp.mkdir(path.dirname(target), { recursive: true });
+    await fsp.writeFile(target, image.bytes);
+  }
+
+  const count = await insertProduct(category, product);
+  return { product, category, imagePaths, count };
+};
+
+const main = async () => {
+  const result = await processIssue({
+    body: process.env.ISSUE_BODY,
+    author: process.env.ISSUE_AUTHOR,
+    allowedAuthors: process.env.ALLOWED_AUTHORS,
+    dryRun: process.argv.includes('--dry-run'),
+  });
+
+  if (result.errors) {
+    // Written to stdout as a markdown list so the workflow can post it back to
+    // the issue verbatim, giving the seller every problem at once.
+    process.stdout.write(`${result.errors.map((error) => `- ${error}`).join('\n')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `added [${result.product.id}] to ${result.category}` +
+      `${result.dryRun ? ' (dry run)' : ` (${result.count} products)`}\n` +
+      `${result.imagePaths.map((relative) => `  ${relative}`).join('\n')}\n`
+  );
+
+  if (process.env.GITHUB_OUTPUT) {
+    await fsp.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `product_id=${result.product.id}\ncategory=${result.category}\n`
+    );
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.exitCode = 1;
+    process.stderr.write(`add-product failed: ${error.message}\n`);
+  });
+}
+
+module.exports = { MAX_STORED_WIDTH, checkAuthor, download, insertProduct, processIssue, reencode };

--- a/tools/authoring/edit-product.js
+++ b/tools/authoring/edit-product.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Applies an edit to one product, from the workflow_dispatch form (option 6-C).
+ *
+ * Editing is the other half of CON-8. It needs no photo, which is why it is a
+ * dispatch form rather than an issue: the only thing an Issue Form gives that
+ * this does not is a file upload.
+ *
+ * The interesting case is marking a single size sold out. That is what the v2
+ * size model made possible, and what the seller will reach for most: one size
+ * goes, the row keeps selling.
+ */
+
+const fsp = require('fs/promises');
+const path = require('path');
+
+const { checkAuthor } = require('./add-product');
+const { listCategories, readCategory } = require('../lib/catalog');
+const { parsePrice } = require('../lib/authoring');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PRODUCTS_DIR = path.join(ROOT, 'products');
+
+// Written in an input to mean "clear this field" — a form cannot express an
+// empty string distinctly from an untouched field.
+const CLEAR = 'remover';
+const NONE = 'nenhum';
+
+/**
+ * Finds a product by id across every category.
+ * @param {string} id The product id.
+ * @returns {{category: string, index: number, products: object[]}|null} Location.
+ */
+const locate = (id) => {
+  for (const category of listCategories(PRODUCTS_DIR)) {
+    const products = readCategory(PRODUCTS_DIR, category);
+    const index = products.findIndex((product) => product.id === id);
+    if (index !== -1) return { category, index, products };
+  }
+  return null;
+};
+
+/**
+ * Applies the requested changes to a product.
+ * @param {object} product The product to change.
+ * @param {object} inputs Raw form inputs.
+ * @returns {{changes: string[]}|{errors: string[]}} What changed, or why not.
+ */
+const applyEdit = (product, inputs) => {
+  const errors = [];
+  const changes = [];
+
+  if (inputs.price) {
+    const price = parsePrice(inputs.price);
+    if (price === null) errors.push(`Preço "${inputs.price}" is not a valid price.`);
+    else {
+      changes.push(`preço: ${product.price} → ${price}`);
+      product.price = price;
+    }
+  }
+
+  if (inputs.oldPrice) {
+    if (inputs.oldPrice.trim().toLowerCase() === CLEAR) {
+      if (product.oldPrice) changes.push(`desconto removido (era ${product.oldPrice})`);
+      delete product.oldPrice;
+    } else {
+      const oldPrice = parsePrice(inputs.oldPrice);
+      if (oldPrice === null) errors.push(`Preço antigo "${inputs.oldPrice}" is not a valid price.`);
+      else if (oldPrice <= product.price) {
+        errors.push(`Preço antigo (${oldPrice}) must be higher than the price (${product.price}).`);
+      } else {
+        changes.push(`preço antigo: ${product.oldPrice || 'nenhum'} → ${oldPrice}`);
+        product.oldPrice = oldPrice;
+      }
+    }
+  }
+
+  if (inputs.description) {
+    if (inputs.description.trim().toLowerCase() === CLEAR) {
+      if (product.description) changes.push('descrição removida');
+      delete product.description;
+    } else {
+      changes.push('descrição atualizada');
+      product.description = inputs.description.trim();
+    }
+  }
+
+  if (inputs.soldOutSizes) {
+    const raw = inputs.soldOutSizes.trim();
+    const clearAll = raw.toLowerCase() === NONE;
+    const wanted = clearAll
+      ? []
+      : raw.split(',').map((value) => value.trim()).filter(Boolean);
+
+    if (!product.sizes.length) {
+      // A row with no units carries the flag itself; there is no size to name.
+      if (!clearAll && wanted.length) {
+        errors.push('This product has no sizes; use "nenhum" to put it back on sale, or a size list is meaningless.');
+      } else if (clearAll) {
+        if (product.soldOut) changes.push('volta a estar disponível');
+        delete product.soldOut;
+      }
+    } else {
+      const known = new Set(product.sizes.map((unit) => unit.size));
+      const unknown = wanted.filter((size) => !known.has(size));
+      if (unknown.length) {
+        errors.push(`This product has no size ${unknown.join(', ')} — it has ${[...known].join(', ')}.`);
+      } else {
+        const before = product.sizes.filter((unit) => unit.soldOut === true).map((unit) => unit.size);
+        product.sizes = product.sizes.map((unit) =>
+          (wanted.includes(unit.size) ? { size: unit.size, soldOut: true } : { size: unit.size })
+        );
+        changes.push(`esgotados: ${before.join(', ') || 'nenhum'} → ${wanted.join(', ') || 'nenhum'}`);
+
+        // soldOut is derived by the build, so the authoring file must not carry a
+        // stale row-level flag alongside units.
+        delete product.soldOut;
+      }
+    }
+  }
+
+  if (errors.length) return { errors };
+  if (!changes.length) return { errors: ['Nothing to change — every field was left blank.'] };
+  return { changes };
+};
+
+const main = async () => {
+  const id = String(process.env.PRODUCT_ID || '').trim();
+
+  const authorError = checkAuthor(process.env.ACTOR, process.env.ALLOWED_AUTHORS);
+  if (authorError) throw new Error(authorError);
+
+  if (!/^\d{10}$/.test(id)) throw new Error(`"${id}" is not a 10-digit product code.`);
+
+  const found = locate(id);
+  if (!found) throw new Error(`No product with code [${id}] exists in the catalog.`);
+
+  const { category, index, products } = found;
+  const result = applyEdit(products[index], {
+    price: process.env.NEW_PRICE,
+    oldPrice: process.env.NEW_OLD_PRICE,
+    soldOutSizes: process.env.SOLD_OUT_SIZES,
+    description: process.env.NEW_DESCRIPTION,
+  });
+
+  if (result.errors) throw new Error(result.errors.join('\n'));
+
+  await fsp.writeFile(
+    path.join(PRODUCTS_DIR, `${category}.json`),
+    `${JSON.stringify(products, null, 4)}\n`,
+    'utf8'
+  );
+
+  const summary = result.changes.map((change) => `- ${change}`).join('\n');
+  process.stdout.write(`[${id}] in ${category}:\n${summary}\n`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    await fsp.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `summary<<EOF_SUMMARY\n${summary}\nEOF_SUMMARY\ncategory=${category}\n`
+    );
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.exitCode = 1;
+    process.stderr.write(`edit-product failed: ${error.message}\n`);
+  });
+}
+
+module.exports = { CLEAR, NONE, applyEdit, locate };

--- a/tools/build.js
+++ b/tools/build.js
@@ -12,6 +12,7 @@ const {
   readCategory,
 } = require('./lib/catalog');
 const { buildImageManifest, manifestOutputs } = require('./lib/images');
+const { TEMPLATE_PATH, renderIssueForm } = require('./lib/issue-form');
 const { loadRegistry, renderRegistryElement } = require('./lib/registry');
 const { toRuntime } = require('./lib/runtime');
 const { buildSocialCard } = require('./lib/social');
@@ -304,6 +305,17 @@ const main = async () => {
   if (applyBlock(html, renderRegistryElement(registry)) !== html) {
     throw new Error(
       'index.html registry block is stale — run `node tools/sync-registry.js` and commit the result'
+    );
+  }
+
+  // The Issue Form's dropdowns *are* the registries, so a stale template means
+  // the seller is offered categories or brands that no longer exist. This is the
+  // closure that keeps the registries load-bearing rather than decorative.
+  const formPath = path.join(ROOT, TEMPLATE_PATH);
+  const currentForm = await fsp.readFile(formPath, 'utf8').catch(() => null);
+  if (currentForm !== renderIssueForm(registry)) {
+    throw new Error(
+      `${TEMPLATE_PATH} is stale — run \`node tools/sync-issue-form.js\` and commit the result`
     );
   }
 

--- a/tools/lib/authoring.js
+++ b/tools/lib/authoring.js
@@ -1,0 +1,392 @@
+'use strict';
+
+/**
+ * Turns a GitHub Issue Form submission into a v2 product.
+ *
+ * This is the logic behind the non-developer authoring path (CON-8). It lives
+ * here, not in the workflow, because a workflow cannot be unit-tested: the
+ * workflow's only job is to pass inputs in and commit the result. Everything
+ * that can be wrong — parsing, validation, id allocation, path construction —
+ * is here and covered by tests, including adversarial ones.
+ *
+ * Every field arriving from an issue body is untrusted. It is validated against
+ * the registries rather than interpolated anywhere, and nothing here builds a
+ * shell command or concatenates JSON.
+ */
+
+const path = require('path');
+
+// Issue Forms render each answer under its field label as a markdown heading.
+const FIELD_HEADING = /^###\s+(.+?)\s*$/;
+
+// What GitHub writes for an untouched optional field.
+const NO_RESPONSE = '_No response_';
+
+// Ten digits, DDMMYYHHmm. OQ-5 established the code is internal, so the format
+// is a free choice; it is kept because the seller already reads codes in this
+// shape, and Wave 7 publishes them as URLs, after which they must never change.
+const ID_LENGTH = 10;
+
+// A single upload should never be this large; anything bigger is a mistake or an
+// attempt to exhaust the runner.
+const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+
+// Variant suffixes, matching validator rule 3.
+const VARIANTS = ['front', 'back'];
+
+/**
+ * Splits an issue body into a map of heading to raw answer.
+ *
+ * Deliberately tolerant about surrounding whitespace and blank lines, because a
+ * human may edit the issue by hand after it is filed.
+ * @param {string} body The issue body.
+ * @returns {object} Heading -> answer, with unanswered fields absent.
+ */
+const parseIssueBody = (body) => {
+  const fields = {};
+  let heading = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (!heading) return;
+    const value = buffer.join('\n').trim();
+    if (value && value !== NO_RESPONSE) fields[heading] = value;
+    buffer = [];
+  };
+
+  for (const line of String(body || '').split(/\r?\n/)) {
+    const match = FIELD_HEADING.exec(line);
+    if (match) {
+      flush();
+      [, heading] = match;
+      continue;
+    }
+    if (heading) buffer.push(line);
+  }
+  flush();
+
+  return fields;
+};
+
+/**
+ * Parses a decimal price written the way a Brazilian seller writes it.
+ *
+ * Accepts "89,90" and "89.90" and "R$ 89,90". Rejects anything else rather than
+ * guessing, because a misread price is worse than a rejected form.
+ * @param {string} raw The raw answer.
+ * @returns {number|null} The price, or null when unparseable.
+ */
+const parsePrice = (raw) => {
+  if (typeof raw !== 'string') return null;
+  const cleaned = raw.replace(/[R$\s]/g, '');
+  if (!/^\d+(?:[.,]\d{1,2})?$/.test(cleaned)) return null;
+  const value = Number(cleaned.replace(',', '.'));
+  return Number.isFinite(value) && value > 0 ? value : null;
+};
+
+/**
+ * Parses the size answer into units.
+ *
+ * A row may hold several units (CON-10), so the form's size control is a
+ * multi-select and this accepts a comma-separated list. Duplicates are rejected
+ * rather than collapsed: two units of the same size is a stock question the form
+ * cannot express, so it should be asked rather than assumed.
+ * @param {string} raw The raw answer.
+ * @returns {{sizes: object[]}|{error: string}} Units, or a rejection reason.
+ */
+const parseSizes = (raw) => {
+  if (!raw) return { sizes: [] };
+
+  const values = String(raw)
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const seen = new Set();
+  for (const value of values) {
+    if (seen.has(value)) return { error: `size "${value}" is listed twice` };
+    seen.add(value);
+  }
+
+  return { sizes: values.map((size) => ({ size })) };
+};
+
+/**
+ * Allocates a free product id.
+ *
+ * The clock alone is not enough: the code has minute granularity, so two
+ * submissions in the same minute would collide — and a collision is a build
+ * error, not a warning. This walks forward a minute at a time until it finds an
+ * unused code, which keeps the code approximately the listing time while
+ * guaranteeing uniqueness.
+ * @param {Set<string>|string[]} taken Ids already in use.
+ * @param {Date} now Current time.
+ * @returns {string} An unused 10-digit id.
+ */
+const allocateId = (taken, now) => {
+  const used = taken instanceof Set ? taken : new Set(taken);
+  const pad = (value) => String(value).padStart(2, '0');
+
+  // A whole day of minutes is far more headroom than one submission needs, and
+  // bounds the loop so a corrupt `taken` set cannot spin forever.
+  for (let offset = 0; offset < 60 * 24; offset += 1) {
+    const at = new Date(now.getTime() + offset * 60_000);
+    const id = [
+      pad(at.getUTCDate()),
+      pad(at.getUTCMonth() + 1),
+      pad(at.getUTCFullYear() % 100),
+      pad(at.getUTCHours()),
+      pad(at.getUTCMinutes()),
+    ].join('');
+    if (!used.has(id)) return id;
+  }
+
+  throw new Error('could not allocate a free product id within 24 hours of now');
+};
+
+/**
+ * Derives the UTC listing timestamp implied by an id.
+ * Kept identical to the migration's derivation so validator rule on
+ * id/listedAt agreement holds.
+ * @param {string} id A 10-digit id.
+ * @returns {string} ISO 8601 UTC timestamp.
+ */
+const listedAtFrom = (id) =>
+  `20${id.slice(4, 6)}-${id.slice(2, 4)}-${id.slice(0, 2)}T${id.slice(6, 8)}:${id.slice(8, 10)}:00Z`;
+
+/**
+ * Builds the repository path for an uploaded image.
+ *
+ * The path is composed from registry values and the allocated id, never from
+ * anything the submitter typed — which is what stops a crafted filename from
+ * escaping the images directory.
+ * @param {object} leaf The category's registry leaf.
+ * @param {string} brand Brand slug.
+ * @param {string} id Allocated product id.
+ * @param {string|null} variant `front`, `back`, or null for a single image.
+ * @returns {string} Repository-relative path.
+ */
+const imagePathFor = (leaf, brand, id, variant = null) => {
+  if (variant !== null && !VARIANTS.includes(variant)) {
+    throw new Error(`unknown image variant "${variant}"`);
+  }
+
+  // Brandless products sit directly in imageDir even where the category uses
+  // brand folders, matching validator rule 4a.
+  const directory = leaf.usesBrandFolders && brand !== 'unbranded'
+    ? `${leaf.imageDir}/${brand}`
+    : leaf.imageDir;
+
+  const suffix = brand === 'unbranded' ? '' : `-${brand}`;
+  const variantSuffix = variant ? `-${variant}` : '';
+
+  return `${directory}/${id}${suffix}${variantSuffix}.jpeg`;
+};
+
+// Sentinel shown in the form for a product with no brand, since `unbranded`
+// carries an empty label and an empty dropdown option is unusable.
+const NO_BRAND_OPTION = 'Sem marca';
+
+/**
+ * Resolves a category answer to its registry leaf, by label or by slug.
+ * @param {object} registry Output of loadRegistry.
+ * @param {string} answer The submitted value.
+ * @returns {object|null} The leaf, or null when it matches no selectable category.
+ */
+const resolveLeaf = (registry, answer) => {
+  const bySlug = registry.bySlug.get(answer);
+  if (bySlug && bySlug.type === 'leaf') return bySlug;
+  return registry.leaves.find((leaf) => leaf.label === answer) || null;
+};
+
+/**
+ * Resolves a brand answer to its slug, by label or by slug.
+ * @param {object} registry Output of loadRegistry.
+ * @param {string} answer The submitted value.
+ * @returns {string|null} The brand slug, or null when unknown.
+ */
+const resolveBrand = (registry, answer) => {
+  if (answer === NO_BRAND_OPTION) return 'unbranded';
+  if (Object.prototype.hasOwnProperty.call(registry.brands, answer)) return answer;
+
+  const match = Object.entries(registry.brands)
+    .find(([slug, brand]) => brand.label === answer && slug !== 'unbranded');
+  return match ? match[0] : null;
+};
+
+/**
+ * Validates a parsed submission against the registries and builds a product.
+ *
+ * Returns errors rather than throwing, so the workflow can post all of them back
+ * to the issue at once instead of the submitter discovering them one at a time.
+ * @param {object} options Build options.
+ * @param {object} options.fields Output of parseIssueBody.
+ * @param {object} options.registry Output of loadRegistry.
+ * @param {Set<string>} options.takenIds Ids already in use.
+ * @param {Date} options.now Current time.
+ * @param {number} options.imageCount How many images were uploaded.
+ * @returns {{product: object, category: string, imagePaths: string[]}|{errors: string[]}} Result.
+ */
+const buildSubmission = ({ fields, registry, takenIds, now, imageCount }) => {
+  const errors = [];
+  const answer = (label) => fields[label];
+
+  // The form shows human labels ("Bonés Masculino"), which read better for a
+  // non-developer, but an issue edited by hand may carry the slug instead.
+  // Accepting both removes the choice between a readable form and a robust
+  // parser. Either way the value is resolved against the registry, never used
+  // as given.
+  const rawCategory = answer('Categoria');
+  const leaf = rawCategory ? resolveLeaf(registry, rawCategory) : null;
+  if (!rawCategory) {
+    errors.push('Categoria is required.');
+  } else if (!leaf) {
+    errors.push(`Categoria "${rawCategory}" is not a category in catalog/categories.json.`);
+  }
+
+  const rawBrand = answer('Marca');
+  const brand = rawBrand ? resolveBrand(registry, rawBrand) : 'unbranded';
+  if (rawBrand && !brand) {
+    errors.push(`Marca "${rawBrand}" is not in catalog/brands.json.`);
+  }
+
+  const price = parsePrice(answer('Preço'));
+  if (price === null) {
+    errors.push('Preço must be a positive number, for example 89,90.');
+  }
+
+  let oldPrice = null;
+  if (answer('Preço antigo')) {
+    oldPrice = parsePrice(answer('Preço antigo'));
+    if (oldPrice === null) {
+      errors.push('Preço antigo must be a positive number, or left blank.');
+    } else if (price !== null && oldPrice <= price) {
+      errors.push(`Preço antigo (${oldPrice}) must be higher than Preço (${price}) to read as a discount.`);
+    }
+  }
+
+  const parsedSizes = parseSizes(answer('Tamanhos'));
+  if (parsedSizes.error) errors.push(parsedSizes.error);
+
+  const sizeNote = answer('Observação de tamanho') || null;
+  if (sizeNote && parsedSizes.sizes && parsedSizes.sizes.length) {
+    errors.push('Fill in either Tamanhos or Observação de tamanho, not both.');
+  }
+  if (sizeNote === 'N/A') {
+    errors.push('Observação de tamanho "N/A" is redundant — leave it blank instead.');
+  }
+
+  if (!imageCount) errors.push('At least one photo is required.');
+  if (imageCount > VARIANTS.length) {
+    errors.push(`At most ${VARIANTS.length} photos are supported (${VARIANTS.join(', ')}).`);
+  }
+
+  if (errors.length) return { errors };
+
+  const id = allocateId(takenIds, now);
+  const product = { id, brand };
+
+  const model = answer('Modelo');
+  if (model) product.model = model;
+
+  product.price = price;
+  if (oldPrice !== null) product.oldPrice = oldPrice;
+
+  product.sizes = parsedSizes.sizes;
+  if (sizeNote) product.sizeNote = sizeNote;
+
+  const description = answer('Descrição');
+  if (description) product.description = description;
+
+  const imagePaths = imageCount === 1
+    ? [imagePathFor(leaf, brand, id)]
+    : VARIANTS.slice(0, imageCount).map((variant) => imagePathFor(leaf, brand, id, variant));
+
+  product.images = imagePaths;
+  product.listedAt = listedAtFrom(id);
+
+  return { product, category: leaf.slug, imagePaths };
+};
+
+/**
+ * Extracts image URLs from an issue body's markdown or HTML image references.
+ *
+ * Only GitHub's own attachment hosts are accepted. A submitter could otherwise
+ * point the workflow at any URL and have the runner fetch it.
+ * @param {string} body The issue body.
+ * @returns {string[]} Accepted image URLs, in order.
+ */
+const extractImageUrls = (body) => {
+  const text = String(body || '');
+  const urls = [];
+
+  const push = (url) => {
+    if (!urls.includes(url)) urls.push(url);
+  };
+
+  for (const [, url] of text.matchAll(/!\[[^\]]*\]\((https:\/\/[^)\s]+)\)/g)) push(url);
+  for (const [, url] of text.matchAll(/<img[^>]+src="(https:\/\/[^"]+)"/g)) push(url);
+
+  return urls.filter(isAllowedAttachmentUrl);
+};
+
+/**
+ * Whether a URL is a GitHub-hosted attachment.
+ * @param {string} url Candidate URL.
+ * @returns {boolean} True when the host is a known GitHub attachment host.
+ */
+const isAllowedAttachmentUrl = (url) => {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+
+  return [
+    'user-images.githubusercontent.com',
+    'github.com',
+    'raw.githubusercontent.com',
+    'private-user-images.githubusercontent.com',
+    'objects.githubusercontent.com',
+  ].includes(parsed.hostname);
+};
+
+/**
+ * Whether a path stays inside the repository's images directory.
+ *
+ * A last line of defence: every path is composed from registry values already,
+ * so this should be unreachable, and is checked anyway because the cost of being
+ * wrong is a write outside the repository.
+ * @param {string} relative Candidate repository-relative path.
+ * @returns {boolean} True when the path is safe to write.
+ */
+const isSafeImagePath = (relative) => {
+  if (typeof relative !== 'string' || !relative) return false;
+  if (relative.includes('..') || relative.includes('\0')) return false;
+  if (path.posix.isAbsolute(relative) || /^[A-Za-z]:/.test(relative)) return false;
+
+  const normalised = path.posix.normalize(relative);
+  return normalised === relative && normalised.startsWith('images/');
+};
+
+module.exports = {
+  ID_LENGTH,
+  NO_BRAND_OPTION,
+  MAX_IMAGE_BYTES,
+  NO_RESPONSE,
+  VARIANTS,
+  allocateId,
+  buildSubmission,
+  extractImageUrls,
+  imagePathFor,
+  isAllowedAttachmentUrl,
+  isSafeImagePath,
+  listedAtFrom,
+  parseIssueBody,
+  parsePrice,
+  parseSizes,
+  resolveBrand,
+  resolveLeaf,
+};

--- a/tools/lib/issue-form.js
+++ b/tools/lib/issue-form.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Renders the "add a product" Issue Form from the registries.
+ *
+ * The form is generated rather than hand-written because its dropdowns *are* the
+ * registries: a hand-maintained copy would become a second source of truth for
+ * category and brand names, which is exactly the problem Wave 3 removed. The
+ * build fails when the committed template is stale, which is what keeps the
+ * registries load-bearing rather than decorative.
+ *
+ * Field labels here must match the labels tools/lib/authoring.js reads, since
+ * GitHub renders each answer under its field label. The two are pinned together
+ * by a test.
+ */
+
+const { NO_BRAND_OPTION } = require('./authoring');
+
+const TEMPLATE_PATH = '.github/ISSUE_TEMPLATE/add-product.yml';
+
+// The label under which each answer appears in the issue body.
+const FIELDS = {
+  category: 'Categoria',
+  brand: 'Marca',
+  model: 'Modelo',
+  price: 'Preço',
+  oldPrice: 'Preço antigo',
+  sizes: 'Tamanhos',
+  sizeNote: 'Observação de tamanho',
+  description: 'Descrição',
+  photos: 'Fotos',
+};
+
+/**
+ * Quotes a value as a YAML double-quoted scalar.
+ * Everything is quoted rather than only what needs it, so a label containing
+ * `&`, `#` or `:` cannot change the document's meaning.
+ * @param {string} value Raw value.
+ * @returns {string} A safely quoted scalar.
+ */
+const yaml = (value) => `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+/**
+ * Renders the Issue Form YAML.
+ * @param {object} registry Output of loadRegistry.
+ * @returns {string} The template contents.
+ */
+const renderIssueForm = (registry) => {
+  const categories = registry.leaves.map((leaf) => leaf.label).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+
+  const brands = Object.entries(registry.brands)
+    .filter(([slug]) => slug !== 'unbranded')
+    .map(([, brand]) => brand.label)
+    .sort((a, b) => a.localeCompare(b, 'pt-BR'));
+
+  const option = (value) => `        - ${yaml(value)}`;
+
+  return [
+    '# Generated from catalog/categories.json and catalog/brands.json by',
+    '# `node tools/sync-issue-form.js`. Do not edit by hand; the build fails when',
+    '# this file is stale. Add a category or brand to the registry and re-run.',
+    'name: Adicionar produto',
+    'description: Cadastrar um novo produto no catálogo',
+    'title: "Novo produto: "',
+    'labels: ["novo-produto"]',
+    'body:',
+    '  - type: markdown',
+    '    attributes:',
+    '      value: |',
+    '        Preencha os campos abaixo e **anexe a foto do produto** no último campo.',
+    '        Ao enviar, um robô cria a alteração e abre um Pull Request para revisão.',
+    '',
+    '  - type: dropdown',
+    '    id: category',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.category)}`,
+    '      description: Onde o produto aparece no catálogo',
+    '      options:',
+    ...categories.map(option),
+    '    validations:',
+    '      required: true',
+    '',
+    '  - type: dropdown',
+    '    id: brand',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.brand)}`,
+    `      description: Escolha ${yaml(NO_BRAND_OPTION)} se o produto não tem marca`,
+    '      options:',
+    option(NO_BRAND_OPTION),
+    ...brands.map(option),
+    '    validations:',
+    '      required: true',
+    '',
+    '  - type: input',
+    '    id: model',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.model)}`,
+    '      description: Linha do produto, quando houver. Por exemplo, Shox ou Campus',
+    '      placeholder: Shox',
+    '',
+    '  - type: input',
+    '    id: price',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.price)}`,
+    '      description: Preço de venda, em reais',
+    '      placeholder: 89,90',
+    '    validations:',
+    '      required: true',
+    '',
+    '  - type: input',
+    '    id: old-price',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.oldPrice)}`,
+    '      description: Só preencha se o produto está com desconto. Precisa ser maior que o preço',
+    '      placeholder: 129,90',
+    '',
+    '  - type: input',
+    '    id: sizes',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.sizes)}`,
+    '      description: |',
+    '        Os tamanhos disponíveis, separados por vírgula. Cada tamanho é uma peça:',
+    '        se vender só uma, a peça sai do catálogo sozinha.',
+    '        Deixe em branco para produtos sem tamanho, como bonés e carteiras.',
+    '      placeholder: P, M, G',
+    '',
+    '  - type: input',
+    '    id: size-note',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.sizeNote)}`,
+    '      description: |',
+    '        Use no lugar de Tamanhos quando não for uma lista.',
+    '        Por exemplo: Tamanho único, Consultar, 37 ao 44.',
+    '      placeholder: Tamanho único',
+    '',
+    '  - type: textarea',
+    '    id: description',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.description)}`,
+    '      description: Detalhes que aparecem no cartão do produto',
+    '      placeholder: "Camiseta Dry Fit, Cor: Preta"',
+    '',
+    '  - type: textarea',
+    '    id: photos',
+    '    attributes:',
+    `      label: ${yaml(FIELDS.photos)}`,
+    '      description: |',
+    '        Arraste a foto para cá, ou toque para escolher da galeria.',
+    '        Pode enviar duas: a primeira é a frente e a segunda o verso.',
+    '    validations:',
+    '      required: true',
+    '',
+  ].join('\n');
+};
+
+module.exports = { FIELDS, TEMPLATE_PATH, renderIssueForm };

--- a/tools/sync-issue-form.js
+++ b/tools/sync-issue-form.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Writes the "add a product" Issue Form from the registries.
+ *
+ *   node tools/sync-issue-form.js           regenerate the template
+ *   node tools/sync-issue-form.js --check   fail if it is stale
+ *
+ * Same closure as tools/sync-registry.js: generated, committed, and checked by
+ * the build. Adding a brand to catalog/brands.json puts it in the dropdown on
+ * the next run — and the build refuses to pass until that run happens, so the
+ * form cannot quietly disagree with the registry.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { loadRegistry } = require('./lib/registry');
+const { TEMPLATE_PATH, renderIssueForm } = require('./lib/issue-form');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const main = () => {
+  const check = process.argv.includes('--check');
+  const target = path.join(ROOT, TEMPLATE_PATH);
+  const expected = renderIssueForm(loadRegistry());
+
+  let current = null;
+  try {
+    current = fs.readFileSync(target, 'utf8');
+  } catch {
+    // Not generated yet.
+  }
+
+  if (current === expected) {
+    process.stdout.write(`issue form: ${TEMPLATE_PATH} is up to date\n`);
+    return;
+  }
+
+  if (check) {
+    process.stderr.write(
+      `issue form: ${TEMPLATE_PATH} is stale — the registries have changed.\n` +
+        '  Run `node tools/sync-issue-form.js` and commit the result.\n'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, expected, 'utf8');
+  process.stdout.write(`issue form: ${TEMPLATE_PATH} ${current === null ? 'created' : 'updated'}\n`);
+};
+
+if (require.main === module) main();
+
+module.exports = { main };


### PR DESCRIPTION
Delivers **CON-8**: the store owner can add and edit products without hand-writing
a PR. $0, nothing outside GitHub, no secret beyond `GITHUB_TOKEN`.

Waves 0–5b were prerequisites for this. Wave 1 made machine-generated PRs
reviewable, Wave 2 gave a validation contract, Wave 3 the dropdown source, Wave 4
targetable fields. This is what they were for.

### ⚠️ Before merging: set `PRODUCT_AUTHORS`

**Settings → Secrets and variables → Actions → Variables → New repository
variable.** A *variable*, not a secret — the workflow reads `${{ vars.… }}`.

```
Name:  PRODUCT_AUTHORS
Value: virtualstoreapp
```

Comma-separate to allow more logins. **With it unset, every submission is
refused** — the correct default for a public repo, but it will look like a broken
robot rather than a configuration gap. The refusal message says so explicitly.

### Adding a product (option 6-A)

`.github/ISSUE_TEMPLATE/add-product.yml` is **generated** from the registries —
64 dropdown options, 26 categories and 38 brands — so it cannot drift from
`catalog/`. The build fails when it is stale, which is the closure that keeps the
registries load-bearing rather than decorative.

Filing the issue runs `add-product.yml`: validate → place the photo → allocate an
id → run the full catalog gate → open a PR. A rejection is commented back on the
issue with **every** problem at once, so the seller is not sent round the loop.

### Editing a product (option 6-C)

`edit-product.yml`, a `workflow_dispatch` form for price, discount, description
and **per-size sold-out**. No photo is involved, so an Issue Form would add
nothing over a dispatch form. Marking one size sold is the edit the v2 size model
made possible and the one that will be used most.

### The architecture choice worth reviewing

**Thin workflow, thick tested script.** A workflow cannot be unit-tested, so the
workflows do nothing but pass values through the environment and open a PR.
Parsing, validation, id allocation, path construction, the author check and the
image decode all live in `tools/lib/authoring.js` and `tools/authoring/`.

That is why 124 tests could cover this wave, including every adversarial case the
plan asked for: `../` in a category **and** in a brand, a nav group as a category,
an off-GitHub photo host, an oversized upload whose `content-length` lies, a
payload that is not an image, a same-minute double submission, a duplicated size.

### Security

This is the first write path in the repository driven by external input.

- **Author allow-list checked before the body is read.** An empty list refuses
  everything rather than allowing everything.
- **Category and brand resolved against the registries**, never used as given, so
  a path cannot be steered out of `images/`. `isSafeImagePath` is a second check
  that should be unreachable and is there anyway.
- **Values reach the script only through the environment** — never interpolated
  into a `run:` script, so a body containing backticks or `$()` cannot become
  shell.
- **Photos fetched only from GitHub attachment hosts**, size-capped *before and
  after* download (`content-length` is a claim, not a guarantee), and re-encoded
  through `sharp` — so "is this an image?" is a decode, not a guess about a
  filename.
- **Product files parsed and re-serialised**, never string-concatenated.
- Least-privilege permissions; third-party actions pinned to commit SHAs; a PR
  rather than a commit to `main`, so the gate and a human both run.

The id allocator reads existing ids and walks forward from the current minute
rather than trusting the clock: the code has minute granularity, so two
submissions in the same minute would collide — and a duplicate id has been a
build error since Wave 2.

### What is *not* verified

**The workflows cannot run outside GitHub, so they are unverified.** The
end-to-end proof here is a dry run of the real script against a real
GitHub-shaped issue body, which produced a valid product, the correct image path
and a re-encoded photo. That is not an Actions run.

**The first live submission is the test.** I would file one deliberately broken
issue first — pick a category, type `de graça` in Preço — which confirms three
things at once: the workflow triggers, the login passes the allow-list, and the
rejection comment posts back. Then file a real one.

### Verification

- `npm test` — 419 passing (was 373), 25 suites
- `npm run build` clean; both staleness gates clean
- Mutation-tested: adding a brand to `catalog/brands.json` without regenerating
  the form fails the build with the exact command to run
- Action SHAs resolved from the GitHub API, not invented

### Note on scope

`deploy.yml` and `test.yml` still use tag refs rather than SHA pins. Left alone
deliberately: `contents: read`, no untrusted input, and they are the working
deploy path. Worth doing separately.

Wave 5b-ii (delivery ladder, AVIF, content hashing) is **deferred rather than
dropped**, with the measurements recorded in the plan.