### PR TITLE
feat: product deep links, per-product pages and SEO [Wave 7]

### DIFF
--- a/docs/architecture/product-image-storage-plan.md
+++ b/docs/architecture/product-image-storage-plan.md
@@ -1164,7 +1164,7 @@ text entering `<meta content="...">` and JSON-LD needs JSON-string escaping, not
 | 5b-i Runtime v2 + per-size availability | 1.5 d | medium | Wave 4 | **done** |
 | 5b-ii Delivery ladder + hashing | 1–2 d | low | Wave 4 | deferred — see note |
 | 6 Non-dev authoring | 3–4 d | **goal (CON-8)** | Waves 1–4 | **done** |
-| 7 Deep links + SEO | 2.5 d | medium (CON-11) | Wave 4 | ready |
+| 7 Deep links + SEO | 2.5 d | medium (CON-11) | Wave 4 | **done** |
 
 **Total ≈ 17–19 days.** No wave is blocked on an unanswered question.
 
@@ -1194,6 +1194,30 @@ into `index.html` as a committed JSON literal, and the build fails when that blo
 `readCategoryDictKeys` — the brace-matching scraper that recovered category names from a JavaScript
 literal — is deleted, and `underwear-man-subcategory` is renamed to `underwear-man` with an alias
 keeping old links alive. Suite: 207 tests.
+
+Wave 7 closed the SEO gap measured in §2.9, which was the largest remaining one in plain terms: **0 of
+241 products were indexable and every shared link previewed the same logo card**, for a business whose
+entire funnel is WhatsApp link-sharing. Both tiers shipped.
+
+**Tier 1** is a `#p/{id}` fragment. Opening a product writes it, closing hands it back to the category,
+and arriving on one renders the whole catalog first so the product is found wherever it lives. The
+fragment is matched against a fixed 10-digit shape and then resolved by *scanning* the rendered
+products — never used to index an object — so it inherits `categoryFromHash`'s discipline. Covered for
+`p/__proto__`, `p/constructor`, `p/../../etc/passwd` and malformed lengths.
+
+**Tier 2** generates `dist/p/{id}/index.html` per product, plus `sitemap.xml` and `robots.txt`. These
+are **real pages, not redirects**: a crawler sees the product without executing JavaScript, and a person
+landing on one sees it too, with a link into the catalog. A redirect would give the crawler nothing.
+
+The JSON-LD escaping is the part worth remembering. The hazard in a script block is not `<` in an
+attribute — it is a `</script>` inside a product description closing the block early, after which the
+rest is parsed as markup. `JSON.stringify` escapes quotes but **not** `<`, so `jsonLd` additionally
+escapes `<`, `>`, `&` and the U+2028/U+2029 separators, which are valid in JSON but not in a JavaScript
+string literal. Two escaping contexts, different rules, both covered.
+
+One bug caught while wiring Tier 1: `renderProducts` writes its category into the fragment, which
+replaced `#p/{id}` with `#all` before the modal could open — so every shared link landed on the
+homepage. The write is now skipped while a product fragment is present.
 
 Wave 6 delivered CON-8, the goal the previous five waves were prerequisites for. A generated Issue Form
 (`.github/ISSUE_TEMPLATE/add-product.yml`, 64 dropdown options straight from the registries) plus
@@ -1356,7 +1380,7 @@ None of these blocks any wave. Each is stated so it can be reversed cheaply.
 | `dist/` size | 36.5 MB | **31.8 MB** — the 45 MB figure was `du` blocks; the ~15 MB target rested on a wrong assumption (Wave 5a) |
 | Derivatives re-encoded per unchanged CI build | ~1,060 | **0** — verified by reproducing the CI mtime condition |
 | Growth thresholds monitored in CI | none | T1/T3/T5 annotated |
-| Products indexable by search engines | 0 of 241 | all |
+| Products indexable by search engines | 0 of 241 | **241 of 241 (Wave 7 done)** |
 | Recurring infrastructure cost | $0 | $0 |
 
 ## 14. What This Plan Assumes

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
   </main>
 
   <footer>
-    <p>Versão: 7.0.0 - 0.61.241</p>
+    <p>Versão: 7.0.1 - 0.61.241</p>
   </footer>
 
   <!-- registry:start -->

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
   </main>
 
   <footer>
-    <p>Versão: 6.2.0 - 0.61.241</p>
+    <p>Versão: 7.0.0 - 0.61.241</p>
   </footer>
 
   <!-- registry:start -->

--- a/scripts.js
+++ b/scripts.js
@@ -141,6 +141,22 @@
     let modal, currentImages = [], currentIndex = 0, currentZoom = 1;
     let currentProductName = '', currentCategory = '', currentProduct = null;
 
+    // Set by the catalog module, which owns the URL fragment.
+    let onProductOpen = null;
+    let onProductClose = null;
+
+    /**
+     * Registers the fragment callbacks.
+     * @param {object} handlers Open and close handlers.
+     */
+    const onNavigate = ({ opened, closed }) => {
+      onProductOpen = opened;
+      onProductClose = closed;
+    };
+
+    /** @returns {object|null} The product currently on screen, if any. */
+    const currentlyOpen = () => currentProduct;
+
     // Build modal HTML markup.
     const createModalMarkup = () => `
       <div id="modal-content">
@@ -258,6 +274,13 @@
       }
 
       modal.style.display = 'flex';
+
+      // An open product is a shareable URL (CON-11). Writing the fragment here
+      // means the browser's own share and copy-link actions carry the product,
+      // with no extra UI. onProductOpen is supplied by the catalog module, which
+      // owns the fragment.
+      if (typeof onProductOpen === 'function') onProductOpen(product);
+
       if (window.gtag) {
         gtag('event', 'open_modal', {
           event_category: 'Product',
@@ -268,6 +291,10 @@
 
     const close = () => {
       modal.style.display = 'none';
+      currentProduct = null;
+      // Hand the fragment back to the category, so closing the modal does not
+      // leave a product URL pointing at a closed modal.
+      if (typeof onProductClose === 'function') onProductClose();
     };
 
     const showPrev = () => {
@@ -321,7 +348,7 @@
       bindModalEvents();
     };
 
-    return { init, open, close };
+    return { init, open, close, onNavigate, currentlyOpen };
   })();
 
   // --- Catalog Module ---
@@ -336,6 +363,10 @@
     // Incremented per render so a slower earlier render cannot append over a
     // newer one. See renderProducts.
     let renderToken = 0;
+
+    // The products currently on screen, so a #p/{id} link can find one without
+    // a second fetch.
+    let renderedProducts = [];
 
     // Newest first. Products carry an explicit UTC `listedAt`, so this replaced
     // a regex that recovered the date from the display name — one of two
@@ -452,9 +483,40 @@
         productListContainer.appendChild(li);
       });
       renderedCategory = category;
-      if (window.location.hash.slice(1) !== category) {
+      renderedProducts = products;
+
+      // A product fragment is more specific than the category behind it, so
+      // rendering the grid must not overwrite it — that would break a shared
+      // link by replacing #p/{id} with #all before the modal could open.
+      if (!productIdFromHash() && window.location.hash.slice(1) !== category) {
         window.location.hash = category;
       }
+    };
+
+    /** @returns {string} The raw fragment, or '' when it cannot be decoded. */
+    const rawHash = () => {
+      try {
+        return decodeURIComponent(window.location.hash.slice(1));
+      } catch {
+        return '';
+      }
+    };
+
+    // A product deep link. `p/` cannot collide with a category, because every
+    // category slug is [a-z0-9-] and carries no slash.
+    const PRODUCT_HASH = /^p\/(\d{10})$/;
+
+    /**
+     * Reads a product id out of the fragment.
+     *
+     * The id is matched against a fixed 10-digit shape and then looked up in the
+     * rendered catalog — never used to index anything directly. Same discipline
+     * as categoryFromHash: the fragment is untrusted.
+     * @returns {string|null} The id, or null when the fragment is not one.
+     */
+    const productIdFromHash = () => {
+      const match = PRODUCT_HASH.exec(rawHash());
+      return match ? match[1] : null;
     };
 
     // The fragment is untrusted, so only known categories are honoured. Both
@@ -462,16 +524,41 @@
     // fragment of "#__proto__" or "#constructor" would otherwise resolve
     // against Object.prototype and be treated as a real category.
     const categoryFromHash = () => {
-      let raw;
-      try {
-        raw = decodeURIComponent(window.location.hash.slice(1));
-      } catch {
-        return null;
-      }
+      const raw = rawHash();
+      if (!raw || PRODUCT_HASH.test(raw)) return null;
 
       // A retired slug keeps resolving, so links shared before a rename still work.
       const resolved = ownProperty(CATEGORY_ALIASES, raw) ? CATEGORY_ALIASES[raw] : raw;
       return ownProperty(CATEGORY_LABELS, resolved) ? resolved : null;
+    };
+
+    /**
+     * Opens the product named by the fragment, if it is on screen.
+     *
+     * Looked up by scanning the rendered products rather than by keying into an
+     * object, so a crafted id cannot reach a prototype property.
+     * @returns {boolean} Whether a product was opened.
+     */
+    const openProductFromHash = () => openProduct(productIdFromHash());
+
+    /**
+     * Opens a product by id, if it is among those rendered.
+     * @param {string|null} id The product id.
+     * @returns {boolean} Whether a product was opened.
+     */
+    const openProduct = (id) => {
+      if (!id) return false;
+
+      const product = renderedProducts.find((entry) => entry.id === id);
+      if (!product) return false;
+
+      Modal.open(
+        product,
+        ownProperty(CATEGORY_LABELS, product.category)
+          ? CATEGORY_LABELS[product.category]
+          : categoryHeading.textContent
+      );
+      return true;
     };
 
     // renderProducts writes the fragment, so it has to be read back for the
@@ -479,6 +566,13 @@
     // already on screen is skipped, which also stops the write from looping.
     const bindHashNavigation = () => {
       window.addEventListener('hashchange', () => {
+        // A product link on an already-rendered catalog only opens the modal.
+        if (openProductFromHash()) return;
+
+        // Coming back from a product link to a category: close the modal rather
+        // than leaving it over the grid.
+        if (Modal.currentlyOpen()) Modal.close();
+
         const category = categoryFromHash();
         if (!category || category === renderedCategory) return;
         renderProducts(category);
@@ -527,7 +621,27 @@
     const init = async () => {
       bindCategoryButtons();
       bindHashNavigation();
-      await renderProducts(categoryFromHash() || ALL_CATEGORY);
+
+      // Opening a product writes #p/{id}, and closing it hands the fragment back
+      // to the category. The modal owns neither, so the catalog supplies both.
+      Modal.onNavigate({
+        opened: (product) => {
+          const fragment = `p/${product.id}`;
+          if (window.location.hash.slice(1) !== fragment) window.location.hash = fragment;
+        },
+        closed: () => {
+          if (productIdFromHash() && renderedCategory) {
+            window.location.hash = renderedCategory;
+          }
+        },
+      });
+
+      // A shared link arrives as #p/{id}, which names a product rather than a
+      // category. The whole catalog is rendered first so the product can be found
+      // wherever it lives, then its modal opens.
+      const deepLinked = productIdFromHash();
+      await renderProducts(deepLinked ? ALL_CATEGORY : categoryFromHash() || ALL_CATEGORY);
+      if (deepLinked) openProduct(deepLinked);
     };
 
     return { init };

--- a/styles.css
+++ b/styles.css
@@ -436,3 +436,52 @@
     font-size: 1.5rem;
   }
   
+/* Product pages (dist/p/{id}/). Generated per product so a crawler sees the
+   product and a shared link previews it — neither was true before, since no
+   product content was server-rendered. */
+.product-page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 20px;
+  text-align: center;
+}
+
+.product-page h1 {
+  font-size: 1.3rem;
+  color: var(--primary-color);
+  margin-bottom: 16px;
+}
+
+.product-page img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.product-page-category {
+  font-size: 0.9rem;
+  color: var(--muted-text);
+  margin: 12px 0 4px;
+}
+
+.product-page .price {
+  display: block;
+  margin: 12px 0;
+}
+
+.product-page .sold-out-label {
+  position: static;
+  display: inline-block;
+  margin: 8px 0;
+  font-size: 1.1rem;
+}
+
+.product-page-link {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 10px 20px;
+  background-color: var(--primary-color);
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+}

--- a/tests/behaviour/catalog.deep-links.test.js
+++ b/tests/behaviour/catalog.deep-links.test.js
@@ -1,0 +1,133 @@
+const path = require('path');
+const {
+  fireEvent,
+  setupDOM,
+  setupGlobalFetchMock,
+  waitFor,
+} = require('../utils/catalogCommon');
+
+const { buildAllCatalog } = require('../../tools/lib/catalog');
+const { loadRegistry } = require('../../tools/lib/registry');
+const { toRuntime } = require('../../tools/lib/runtime');
+
+const PRODUCTS_DIR = path.join(__dirname, '../../products');
+const { brands } = loadRegistry();
+const catalog = buildAllCatalog(PRODUCTS_DIR).map((p) => ({ ...toRuntime(p, brands), category: p.category }));
+
+const SAMPLE = catalog.find((p) => p.category === 'caps-man');
+
+const bootstrap = (hash = '') => {
+  window.__isTest = true;
+  global.gtag = jest.fn();
+  document.body.innerHTML = '';
+  window.location.hash = hash;
+  setupGlobalFetchMock();
+  setupDOM();
+};
+
+const modal = () => document.getElementById('product-modal');
+const heading = () => document.getElementById('category-heading').textContent;
+const cards = () => document.querySelectorAll('#product-list .product-item');
+const hash = () => window.location.hash;
+
+const navigate = (to) => {
+  window.location.hash = to;
+  window.dispatchEvent(new Event('hashchange'));
+};
+
+describe('Product deep links', () => {
+  describe('arriving on a shared link', () => {
+    it('opens the product named in the fragment', async () => {
+      bootstrap(`p/${SAMPLE.id}`);
+      await waitFor(() => expect(modal()).toHaveStyle({ display: 'flex' }));
+      expect(document.getElementById('modal-image').getAttribute('src')).toBeTruthy();
+    });
+
+    // The whole catalog is rendered so the product can be found wherever it
+    // lives, rather than requiring the link to name a category too.
+    it('renders the full catalog behind the modal', async () => {
+      bootstrap(`p/${SAMPLE.id}`);
+      await waitFor(() => expect(cards().length).toBe(catalog.length));
+      expect(heading()).toBe('Novidades');
+    });
+
+    // renderProducts writes the category into the fragment; without a guard it
+    // would replace #p/{id} with #all before the modal could open.
+    it('keeps the product fragment through the initial render', async () => {
+      bootstrap(`p/${SAMPLE.id}`);
+      await waitFor(() => expect(modal()).toHaveStyle({ display: 'flex' }));
+      expect(hash()).toBe(`#p/${SAMPLE.id}`);
+    });
+
+    it('falls back to the homepage for an id no product has', async () => {
+      bootstrap('p/0000000000');
+      await waitFor(() => expect(cards().length).toBeGreaterThan(0));
+      expect(modal()).not.toHaveStyle({ display: 'flex' });
+      expect(heading()).toBe('Novidades');
+    });
+  });
+
+  describe('writing the fragment', () => {
+    it('writes #p/{id} when a product is opened', async () => {
+      bootstrap();
+      await waitFor(() => expect(cards().length).toBeGreaterThan(0));
+
+      fireEvent.click(cards()[0]);
+      await waitFor(() => expect(modal()).toHaveStyle({ display: 'flex' }));
+      expect(hash()).toMatch(/^#p\/\d{10}$/);
+    });
+
+    it('hands the fragment back to the category when closed', async () => {
+      bootstrap();
+      await waitFor(() => expect(cards().length).toBeGreaterThan(0));
+
+      fireEvent.click(cards()[0]);
+      await waitFor(() => expect(hash()).toMatch(/^#p\//));
+
+      fireEvent.click(document.getElementById('modal-close'));
+      expect(hash()).toBe('#all');
+    });
+  });
+
+  describe('untrusted fragment', () => {
+    // Same discipline as categoryFromHash: matched against a fixed shape, then
+    // looked up by scanning, never used to index an object.
+    it.each([
+      'p/__proto__',
+      'p/constructor',
+      'p/../../etc/passwd',
+      'p/12345',
+      'p/12345678901',
+      'p/abcdefghij',
+      'p/',
+    ])('ignores %s', async (fragment) => {
+      bootstrap(fragment);
+      await waitFor(() => expect(cards().length).toBeGreaterThan(0));
+      expect(modal()).not.toHaveStyle({ display: 'flex' });
+    });
+
+    it('still treats a category fragment as a category', async () => {
+      bootstrap('caps-man');
+      await waitFor(() => expect(heading()).toBe('Bonés Masculino'));
+      expect(modal()).not.toHaveStyle({ display: 'flex' });
+    });
+  });
+
+  describe('back and forward', () => {
+    it('opens the modal when navigating to a product fragment', async () => {
+      bootstrap();
+      await waitFor(() => expect(cards().length).toBeGreaterThan(0));
+
+      navigate(`p/${SAMPLE.id}`);
+      await waitFor(() => expect(modal()).toHaveStyle({ display: 'flex' }));
+    });
+
+    it('closes the modal when navigating back to a category', async () => {
+      bootstrap(`p/${SAMPLE.id}`);
+      await waitFor(() => expect(modal()).toHaveStyle({ display: 'flex' }));
+
+      navigate('all');
+      await waitFor(() => expect(modal()).not.toHaveStyle({ display: 'flex' }));
+    });
+  });
+});

--- a/tests/footer/__snapshots__/footer.test.js.snap
+++ b/tests/footer/__snapshots__/footer.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Footer CSS and Markup renders footer markup as expected 1`] = `
 "<footer>
-    <p>Versão: 6.2.0 - 0.61.241</p>
+    <p>Versão: 7.0.0 - 0.61.241</p>
   </footer>"
 `;

--- a/tests/footer/__snapshots__/footer.test.js.snap
+++ b/tests/footer/__snapshots__/footer.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Footer CSS and Markup renders footer markup as expected 1`] = `
 "<footer>
-    <p>Versão: 7.0.0 - 0.61.241</p>
+    <p>Versão: 7.0.1 - 0.61.241</p>
   </footer>"
 `;

--- a/tests/tools/product-pages.test.js
+++ b/tests/tools/product-pages.test.js
@@ -1,0 +1,229 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  SITE,
+  jsonLd,
+  productUrl,
+  renderProductPage,
+  renderRobots,
+  renderSitemap,
+  sizeSummary,
+  structuredData,
+} = require('../../tools/lib/product-pages');
+
+const ROOT = path.join(__dirname, '../..');
+
+const product = (overrides = {}) => ({
+  id: '2307251157',
+  name: '[2307251157] Gucci',
+  brand: 'gucci',
+  brandLabel: 'Gucci',
+  price: 89.9,
+  sizes: [{ size: 'M' }, { size: 'G' }],
+  images: ['images/man/belts/2307251157-gucci.jpeg'],
+  listedAt: '2025-07-23T11:57:00Z',
+  category: 'belts-man',
+  media: [{
+    src: 'images/man/belts/2307251157-gucci.jpeg',
+    webp: 'images/man/belts/2307251157-gucci.webp',
+    full: 'images/man/belts/2307251157-gucci.jpg',
+    width: 1200,
+    height: 1500,
+  }],
+  ...overrides,
+});
+
+const page = (overrides) => renderProductPage(product(overrides), 'Cintos Masculino');
+
+describe('sizeSummary', () => {
+  it('lists the sizes still available', () => {
+    expect(sizeSummary(product())).toBe('Tamanhos: M, G');
+  });
+
+  // A partly sold-out row keeps selling, so the page shows what is left.
+  it('omits a sold-out size', () => {
+    expect(sizeSummary(product({ sizes: [{ size: 'M', soldOut: true }, { size: 'G' }] })))
+      .toBe('Tamanho: G');
+  });
+
+  it('reads Esgotado when every size is gone', () => {
+    expect(sizeSummary(product({ sizes: [{ size: 'M', soldOut: true }] }))).toBe('Esgotado');
+  });
+
+  it('uses the note when there are no sizes', () => {
+    expect(sizeSummary(product({ sizes: [], sizeNote: 'Tamanho único' }))).toBe('Tamanho único');
+  });
+
+  it('is empty for a product with neither', () => {
+    expect(sizeSummary(product({ sizes: [] }))).toBe('');
+  });
+});
+
+describe('jsonLd', () => {
+  // The danger in a script block is not `<` in an attribute but a `</script>`
+  // closing the block early. JSON.stringify does not escape it.
+  it('neutralises a closing script tag', () => {
+    const out = jsonLd({ description: 'x</script><img onerror=alert(1)>' });
+    expect(out).not.toContain('</script>');
+    expect(out).toContain('\\u003c/script\\u003e');
+    expect(JSON.parse(out).description).toBe('x</script><img onerror=alert(1)>');
+  });
+
+  it('escapes the line separators that are valid JSON but not valid JS', () => {
+    expect(jsonLd({ a: '\u2028\u2029' })).toBe('{"a":"\\u2028\\u2029"}');
+  });
+
+  it('round-trips ordinary text unchanged', () => {
+    expect(JSON.parse(jsonLd({ a: 'Calças Jeans — 42' })).a).toBe('Calças Jeans — 42');
+  });
+});
+
+describe('structuredData', () => {
+  it('describes the product and its offer', () => {
+    const data = structuredData(product(), 'Cintos Masculino');
+    expect(data['@type']).toBe('Product');
+    expect(data.sku).toBe('2307251157');
+    expect(data.brand).toEqual({ '@type': 'Brand', name: 'Gucci' });
+    expect(data.offers).toMatchObject({
+      '@type': 'Offer',
+      price: '89.90',
+      priceCurrency: 'BRL',
+      availability: 'https://schema.org/InStock',
+    });
+  });
+
+  it('marks a fully sold-out product out of stock', () => {
+    const data = structuredData(product({ soldOut: true }), 'Cintos Masculino');
+    expect(data.offers.availability).toBe('https://schema.org/OutOfStock');
+  });
+
+  // A partly sold-out row is still in stock — the point of tracking units.
+  it('keeps a partly sold-out product in stock', () => {
+    const data = structuredData(
+      product({ sizes: [{ size: 'M', soldOut: true }, { size: 'G' }] }),
+      'Cintos Masculino'
+    );
+    expect(data.offers.availability).toBe('https://schema.org/InStock');
+  });
+
+  it('omits brand for an unbranded product', () => {
+    expect('brand' in structuredData(product({ brandLabel: '' }), 'x')).toBe(false);
+  });
+
+  it('uses an absolute image URL, since crawlers do not resolve relative ones', () => {
+    expect(structuredData(product(), 'x').image).toBe(`${SITE}/images/man/belts/2307251157-gucci.jpg`);
+  });
+});
+
+describe('renderProductPage', () => {
+  it('carries a per-product canonical, title and preview image', () => {
+    const html = page();
+    expect(html).toContain(`<link rel="canonical" href="${productUrl(product())}">`);
+    expect(html).toContain('<title>[2307251157] Gucci — M/A Imports</title>');
+    expect(html).toContain(`og:image" content="${SITE}/images/man/belts/2307251157-gucci.jpg"`);
+    expect(html).toContain('og:type" content="product"');
+  });
+
+  it('server-renders the product, so a crawler sees it without running JS', () => {
+    const html = page();
+    expect(html).toContain('<h1>[2307251157] Gucci</h1>');
+    expect(html).toContain('Cintos Masculino');
+    expect(html).toMatch(/R\$\s?89,90/);
+  });
+
+  it('links back into the catalog at the product', () => {
+    expect(page()).toContain('href="../../#p/2307251157"');
+  });
+
+  it('embeds parseable JSON-LD', () => {
+    const match = /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/.exec(page());
+    expect(JSON.parse(match[1])['@type']).toBe('Product');
+  });
+
+  it('escapes hostile product text in every context', () => {
+    const hostile = page({
+      name: '<img src=x onerror=alert(1)> "Nike"',
+      description: '</script><script>alert(1)</script>',
+    });
+    // One img: the product photo. The one in the name did not become markup.
+    expect(hostile.match(/<img /g)).toHaveLength(2); // logo + product photo
+    expect(hostile).not.toContain('<img src=x');
+    expect(hostile).not.toContain('</script><script>alert(1)');
+    const match = /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/.exec(hostile);
+    expect(JSON.parse(match[1]).description).toBe('</script><script>alert(1)</script>');
+  });
+
+  it('renders without media, for a product whose images are not built', () => {
+    const html = page({ media: [] });
+    expect(html).not.toContain('og:image');
+    expect(html).toContain('<h1>');
+  });
+
+  it('shows the sold-out label only when the row is gone', () => {
+    expect(page({ soldOut: true })).toContain('class="sold-out-label"');
+    expect(page()).not.toContain('class="sold-out-label"');
+  });
+});
+
+describe('renderSitemap', () => {
+  it('lists the homepage and every product', () => {
+    const xml = renderSitemap([product(), product({ id: '0101250900' })]);
+    expect(xml).toContain(`<loc>${SITE}/</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/p/2307251157/</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/p/0101250900/</loc>`);
+  });
+
+  it('uses the sitemaps.org namespace', () => {
+    expect(renderSitemap([])).toContain('http://www.sitemaps.org/schemas/sitemap/0.9');
+  });
+
+  it('dates each entry from listedAt', () => {
+    expect(renderSitemap([product()])).toContain('<lastmod>2025-07-23</lastmod>');
+  });
+});
+
+describe('renderRobots', () => {
+  it('allows crawling and points at the sitemap', () => {
+    const robots = renderRobots();
+    expect(robots).toContain('Allow: /');
+    expect(robots).toContain(`Sitemap: ${SITE}/sitemap.xml`);
+  });
+});
+
+describe('The built output', () => {
+  const dist = path.join(ROOT, 'dist');
+  const skip = !fs.existsSync(path.join(dist, 'p'));
+
+  it('writes a page per product', () => {
+    if (skip) return;
+    const all = JSON.parse(fs.readFileSync(path.join(dist, 'products', 'all.json'), 'utf8'));
+    const pages = fs.readdirSync(path.join(dist, 'p'));
+    expect(pages).toHaveLength(all.length);
+    all.forEach((entry) => {
+      expect(fs.existsSync(path.join(dist, 'p', entry.id, 'index.html'))).toBe(true);
+    });
+  });
+
+  it('writes a sitemap covering every product', () => {
+    if (skip) return;
+    const all = JSON.parse(fs.readFileSync(path.join(dist, 'products', 'all.json'), 'utf8'));
+    const xml = fs.readFileSync(path.join(dist, 'sitemap.xml'), 'utf8');
+    expect((xml.match(/<loc>/g) || []).length).toBe(all.length + 1);
+  });
+
+  it('writes robots.txt', () => {
+    if (skip) return;
+    expect(fs.readFileSync(path.join(dist, 'robots.txt'), 'utf8')).toContain('Sitemap:');
+  });
+
+  it('produces valid JSON-LD on every page', () => {
+    if (skip) return;
+    for (const id of fs.readdirSync(path.join(dist, 'p'))) {
+      const html = fs.readFileSync(path.join(dist, 'p', id, 'index.html'), 'utf8');
+      const match = /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/.exec(html);
+      expect(match).toBeTruthy();
+      expect(() => JSON.parse(match[1])).not.toThrow();
+    }
+  });
+});

--- a/tools/build.js
+++ b/tools/build.js
@@ -13,6 +13,7 @@ const {
 } = require('./lib/catalog');
 const { buildImageManifest, manifestOutputs } = require('./lib/images');
 const { TEMPLATE_PATH, renderIssueForm } = require('./lib/issue-form');
+const { renderProductPage, renderRobots, renderSitemap } = require('./lib/product-pages');
 const { loadRegistry, renderRegistryElement } = require('./lib/registry');
 const { toRuntime } = require('./lib/runtime');
 const { buildSocialCard } = require('./lib/social');
@@ -99,7 +100,49 @@ const writeProducts = async (manifest, brands) => {
     await fsp.rm(path.join(outputDir, file));
   }
 
-  return { categories: categories.length, products: all.length, stale: stale.length };
+  return { categories: categories.length, products: all.length, stale: stale.length, all };
+};
+
+/**
+ * Writes a page per product, plus the sitemap and robots.txt.
+ *
+ * Before this, no product content was server-rendered, so none of the 241 was
+ * indexable and every shared link previewed the same logo card (§2.9).
+ * @param {object[]} products Compiled runtime products, with media and category.
+ * @param {object} registry Output of loadRegistry.
+ * @returns {Promise<number>} Pages written.
+ */
+const writeProductPages = async (products, registry) => {
+  const label = (slug) => {
+    const node = registry.bySlug.get(slug);
+    return node && node.label ? node.label : 'Produtos';
+  };
+
+  for (const product of products) {
+    const directory = path.join(DIST, 'p', product.id);
+    await fsp.mkdir(directory, { recursive: true });
+    await fsp.writeFile(
+      path.join(directory, 'index.html'),
+      renderProductPage(product, label(product.category)),
+      'utf8'
+    );
+  }
+
+  await fsp.writeFile(path.join(DIST, 'sitemap.xml'), renderSitemap(products), 'utf8');
+  await fsp.writeFile(path.join(DIST, 'robots.txt'), renderRobots(), 'utf8');
+
+  // A deleted product would otherwise keep its page and stay in the sitemap, so
+  // the same pruning the product payloads get applies here.
+  const live = new Set(products.map((product) => product.id));
+  const existing = await fsp.readdir(path.join(DIST, 'p')).catch(() => []);
+  let pruned = 0;
+  for (const entry of existing) {
+    if (live.has(entry)) continue;
+    await fsp.rm(path.join(DIST, 'p', entry), { recursive: true, force: true });
+    pruned += 1;
+  }
+
+  return { pages: products.length, pruned };
 };
 
 // Files scanned for direct image references. These are served verbatim, so any
@@ -331,9 +374,13 @@ const main = async () => {
     throw new Error(`${errors.length} catalog problem(s):\n  ${errors.join('\n  ')}`);
   }
 
-  const { categories, products, stale } = await writeProducts(manifest, registry.brands);
+  const { categories, products, stale, all } = await writeProducts(manifest, registry.brands);
   log(`products: ${products} products across ${categories} categories`);
   if (stale) log(`products: ${stale} stale file(s) pruned`);
+
+  const pages = await writeProductPages(all, registry);
+  log(`pages: ${pages.pages} product page(s), sitemap and robots.txt`);
+  if (pages.pruned) log(`pages: ${pages.pruned} stale page(s) pruned`);
   if (warnings.length) log(`products: ${warnings.length} warning(s) above`);
 
   for (const file of STATIC_FILES) {

--- a/tools/lib/product-pages.js
+++ b/tools/lib/product-pages.js
@@ -1,0 +1,225 @@
+'use strict';
+
+/**
+ * Generates a page per product, plus a sitemap and robots.txt.
+ *
+ * Closes the gap measured in §2.9: no product content is server-rendered, so all
+ * 241 products are invisible to a crawler that does not execute JavaScript, and
+ * every link shared over WhatsApp previews the same logo card — for a business
+ * whose entire funnel is WhatsApp link-sharing.
+ *
+ * These are real pages, not redirects. A crawler sees the product; a person
+ * landing on one sees it too, with a link into the catalog. A redirect would
+ * hand the crawler nothing and cost the visitor a round trip.
+ *
+ * Two escaping contexts, and they are not the same:
+ *  - HTML text and quoted attributes, handled by escapeHtml;
+ *  - JSON-LD, where the danger is not `<` in an attribute but a `</script>` in a
+ *    product description closing the block early. JSON.stringify escapes quotes
+ *    but not `<`, so jsonLd additionally escapes it as <.
+ */
+
+const SITE = 'https://virtualstoreapp.github.io/ma-imports';
+
+/** Escapes for HTML text and quoted-attribute contexts. */
+const escapeHtml = (value) =>
+  String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+/**
+ * Serialises a value for embedding in a <script type="application/ld+json">.
+ *
+ * `<` becomes <, which JSON.stringify does not do. Without it a description
+ * containing "</script>" would close the block and everything after it would be
+ * parsed as markup.
+ * @param {object} value The structured data.
+ * @returns {string} Safe JSON.
+ */
+const jsonLd = (value) =>
+  JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    // Valid in JSON but not in a JavaScript string literal, and a script block
+    // is parsed as script before it is parsed as JSON.
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+
+/** @returns {string} The canonical URL of a product page. */
+const productUrl = (product) => `${SITE}/p/${product.id}/`;
+
+/**
+ * Renders the human-readable size line.
+ * @param {object} product Runtime product.
+ * @returns {string} A short description of availability.
+ */
+const sizeSummary = (product) => {
+  const sizes = product.sizes || [];
+  if (!sizes.length) return product.sizeNote || '';
+
+  const available = sizes.filter((unit) => unit.soldOut !== true).map((unit) => unit.size);
+  if (!available.length) return 'Esgotado';
+  return `${available.length > 1 ? 'Tamanhos' : 'Tamanho'}: ${available.join(', ')}`;
+};
+
+/**
+ * Builds the schema.org Product for a product.
+ *
+ * `availability` is derived from the row: a partly sold-out row is still in
+ * stock, which is the whole point of tracking units.
+ * @param {object} product Runtime product.
+ * @param {string} categoryLabel The category's display label.
+ * @returns {object} JSON-LD structured data.
+ */
+const structuredData = (product, categoryLabel) => {
+  const image = (product.media || [])[0];
+
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: product.name,
+    category: categoryLabel,
+    url: productUrl(product),
+    sku: product.id,
+    offers: {
+      '@type': 'Offer',
+      price: product.price.toFixed(2),
+      priceCurrency: 'BRL',
+      availability: product.soldOut === true
+        ? 'https://schema.org/OutOfStock'
+        : 'https://schema.org/InStock',
+      url: productUrl(product),
+    },
+  };
+
+  if (product.description) data.description = product.description;
+  if (product.brandLabel) data.brand = { '@type': 'Brand', name: product.brandLabel };
+  if (image) data.image = `${SITE}/${image.full}`;
+
+  return data;
+};
+
+/**
+ * Renders one product page.
+ * @param {object} product Runtime product, with media attached.
+ * @param {string} categoryLabel The category's display label.
+ * @returns {string} The page HTML.
+ */
+const renderProductPage = (product, categoryLabel) => {
+  const media = (product.media || [])[0];
+  const title = `${product.name} — M/A Imports`;
+  const summary = [categoryLabel, sizeSummary(product), product.description]
+    .filter(Boolean)
+    .join('. ');
+
+  const price = product.price.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeHtml(summary)}">
+  <link rel="canonical" href="${productUrl(product)}">
+
+  <!-- Per-product preview, so a link shared over WhatsApp shows the product
+       instead of the site logo. Crawlers do not resolve relative URLs. -->
+  <meta property="og:type" content="product">
+  <meta property="og:site_name" content="M/A Imports">
+  <meta property="og:locale" content="pt_BR">
+  <meta property="og:title" content="${escapeHtml(product.name)}">
+  <meta property="og:description" content="${escapeHtml(summary)}">
+  <meta property="og:url" content="${productUrl(product)}">
+${media ? `  <meta property="og:image" content="${SITE}/${escapeHtml(media.full)}">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="${escapeHtml(media.width)}">
+  <meta property="og:image:height" content="${escapeHtml(media.height)}">
+  <meta property="og:image:alt" content="${escapeHtml(product.name)}">
+` : ''}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(product.name)}">
+  <meta name="twitter:description" content="${escapeHtml(summary)}">
+${media ? `  <meta name="twitter:image" content="${SITE}/${escapeHtml(media.full)}">
+` : ''}
+  <link rel="stylesheet" href="../../styles.css">
+
+  <script type="application/ld+json">
+${jsonLd(structuredData(product, categoryLabel))}
+  </script>
+</head>
+<body>
+  <header>
+    <div class="header-logo">
+      <a href="../../"><img src="../../images/logo.jpeg" alt="M/A Imports Logo"></a>
+    </div>
+  </header>
+
+  <main class="product-page">
+    <h1>${escapeHtml(product.name)}</h1>
+${media ? `    <picture>
+      <source srcset="../../${escapeHtml(media.webp)}" type="image/webp">
+      <img src="../../${escapeHtml(media.full)}" alt="${escapeHtml(product.name)}" width="${escapeHtml(media.width)}" height="${escapeHtml(media.height)}">
+    </picture>
+` : ''}
+    <p class="product-page-category">${escapeHtml(categoryLabel)}</p>
+${product.description ? `    <p class="description">${escapeHtml(product.description)}</p>\n` : ''}${sizeSummary(product) ? `    <p class="size-note">${escapeHtml(sizeSummary(product))}</p>\n` : ''}    <p class="price">${escapeHtml(price)}</p>
+${product.soldOut === true ? '    <p class="sold-out-label">Esgotado</p>\n' : ''}
+    <p><a class="product-page-link" href="../../#p/${escapeHtml(product.id)}">Ver no catálogo</a></p>
+  </main>
+
+  <footer>
+    <p><a href="../../">M/A Imports</a></p>
+  </footer>
+</body>
+</html>
+`;
+};
+
+/**
+ * Renders the sitemap.
+ * @param {object[]} products Runtime products.
+ * @returns {string} sitemap.xml contents.
+ */
+const renderSitemap = (products) => {
+  const entries = [`  <url><loc>${SITE}/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>`];
+
+  for (const product of products) {
+    // lastmod uses listedAt: it is the only date the catalog records, and it is
+    // honest — a product page changes when the product does.
+    entries.push(
+      `  <url><loc>${productUrl(product)}</loc>` +
+        `<lastmod>${product.listedAt.slice(0, 10)}</lastmod>` +
+        `<changefreq>monthly</changefreq><priority>0.8</priority></url>`
+    );
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries.join('\n')}
+</urlset>
+`;
+};
+
+/** @returns {string} robots.txt contents. */
+const renderRobots = () => `User-agent: *
+Allow: /
+
+Sitemap: ${SITE}/sitemap.xml
+`;
+
+module.exports = {
+  SITE,
+  escapeHtml,
+  jsonLd,
+  productUrl,
+  renderProductPage,
+  renderRobots,
+  renderSitemap,
+  sizeSummary,
+  structuredData,
+};


### PR DESCRIPTION
Closes the gap measured in §2.9 and the largest one remaining: 0 of 241 products were indexable and every link shared over WhatsApp previewed the same logo card, for a business whose entire funnel is WhatsApp link-sharing. OQ-6 asked for both tiers; both ship here.

Tier 1 — shareable links. Opening a product writes #p/{id}, closing it hands the fragment back to the category, and arriving on one renders the whole catalog first so the product is found wherever it lives. No new UI: the browser's own share and copy-link actions now carry the product.

Tier 2 — per-product pages. dist/p/{id}/index.html for all 241, plus sitemap.xml and robots.txt. These are real pages, not redirects: a crawler sees the product without executing JavaScript, and a person landing on one sees it too with a link into the catalog. Each carries its own canonical, Open Graph and Twitter tags with the product photo, and schema.org Product/Offer JSON-LD. Availability is derived from the row, so a partly sold-out product is still InStock — the point of tracking units.

Security, both escaping contexts:
- the fragment is matched against a fixed 10-digit shape and then resolved by scanning the rendered products, never used to index an object, so it inherits categoryFromHash's discipline. Covered for p/__proto__, p/constructor, p/../../etc/passwd and malformed lengths
- JSON-LD is the second context and the rules differ. The hazard is not `<` in an attribute but a `</script>` inside a description closing the block early, after which the rest parses as markup. JSON.stringify escapes quotes but not `<`, so jsonLd escapes `<`, `>`, `&` and U+2028/U+2029 — the last two being valid JSON but invalid in a JavaScript string literal

One bug found while wiring Tier 1: renderProducts writes its category into the fragment, which replaced #p/{id} with #all before the modal could open — so every shared link would have landed on the homepage. The write is now skipped while a product fragment is present, with a test that pins it.

Stale pages are pruned, so a deleted product does not keep a live URL or stay in the sitemap — the same failure Wave 3's rename left behind in dist/products.

Tests: 463 passing (was 419), 27 suites. Verified over HTTP against a served dist/: /, /robots.txt, /sitemap.xml and /p/{id}/ all 200, an unknown id 404s, and the product page carries its h1, price, sizes and canonical with no JavaScript.

Footer version 6.2.0 -> 7.0.0.

Refs docs/architecture/product-image-storage-plan.md (Wave 7)