### PR TITLE
fix: gate add-product on the issue-form body, not a label

### DIFF
--- a/.github/workflows/add-product.yml
+++ b/.github/workflows/add-product.yml
@@ -32,7 +32,18 @@ concurrency:
 
 jobs:
   add:
-    if: contains(github.event.issue.labels.*.name, 'novo-produto')
+    # The form's own shape is the trigger, not a label. GitHub applies a label
+    # named in an issue template only if it already exists in the repository, and
+    # `novo-produto` did not — so a label-gated job never ran and the submission
+    # failed silently, with nothing on the issue to say why. `### Categoria` and
+    # `### Fotos` are the headings parseIssueBody reads, and both answers are
+    # required by the form, so a body carrying them is a submission by
+    # construction. The label still triggers a run, which is how an issue filed
+    # before this change can be replayed by labelling it.
+    if: >-
+      (contains(github.event.issue.body, '### Categoria')
+      && contains(github.event.issue.body, '### Fotos'))
+      || contains(github.event.issue.labels.*.name, 'novo-produto')
     runs-on: ubuntu-latest
 
     steps:
@@ -90,6 +101,20 @@ jobs:
           } > "$RUNNER_TEMP/comment.md"
           gh issue comment "$ISSUE_NUMBER" --body-file "$RUNNER_TEMP/comment.md"
           exit 1
+
+      # The label is no longer what triggers the job, but the PR still carries it
+      # so submissions can be filtered. Created here rather than assumed, because
+      # a missing label is what broke this path in the first place. `--force`
+      # makes the step idempotent instead of failing on the second run.
+      - name: Ensure the tracking label exists
+        if: steps.build.outcome == 'success' && steps.validate.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create novo-produto \
+            --color 0E8A16 \
+            --description 'Cadastro de produto pelo formulário' \
+            --force
 
       - name: Open the pull request
         if: steps.build.outcome == 'success' && steps.validate.outcome == 'success'

--- a/tests/tools/add-product.test.js
+++ b/tests/tools/add-product.test.js
@@ -257,4 +257,17 @@ describe('The generated issue form', () => {
       expect(template).not.toContain(`- "${group.navLabel}"\n`);
     });
   });
+
+  // The workflow decides whether an issue is a submission by looking for these
+  // two headings in its body, rather than for a label GitHub only applies when
+  // it already exists. That makes the field labels load-bearing twice over, so
+  // they are pinned here too: renaming one without updating the gate would stop
+  // the workflow from firing at all, which is the silent failure this replaced.
+  it('is recognised by the workflow that reads it', () => {
+    const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/add-product.yml'), 'utf8');
+
+    expect(workflow).toContain(`'### ${FIELDS.category}'`);
+    expect(workflow).toContain(`'### ${FIELDS.photos}'`);
+    expect(workflow).not.toMatch(/^\s*if: contains\(github\.event\.issue\.labels/m);
+  });
 });


### PR DESCRIPTION
GitHub applies a label named in an issue template only if that label already exists in the repository, and `novo-produto` never did — so the label-gated job never ran. A submission produced no PR and no comment explaining why, which is the one failure mode this path cannot afford: the seller has no way to tell a rejected form from a broken robot.

The gate now looks for `### Categoria` and `### Fotos` in the body. Both are required answers, and they are the headings parseIssueBody already reads, so a body carrying them is a submission by construction. The label clause stays as an OR, so labelling an issue filed earlier still replays it.

The PR keeps the label for filtering, but it is now created with `gh label create --force` before the PR is opened rather than assumed, since that was the second dependency on a label nobody had made.

A test pins the two headings to the form's field labels, which are now load-bearing in three places: renaming one without the others would go back to never firing.