### PR TITLE
chore: add a temporary probe issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/zz-probe.yml
+++ b/.github/ISSUE_TEMPLATE/zz-probe.yml
@@ -1,0 +1,20 @@
+# TEMPORARY. A deliberately minimal form, copied from GitHub's own example and
+# stripped of everything add-product.yml does that a plain form does not: no
+# dropdowns, no accented labels, no `labels:` key, ASCII only.
+#
+# It exists to answer one question the sign-in wall stops us asking remotely —
+# does this repository render *any* issue form? If this appears in the chooser
+# and "Adicionar produto" does not, the fault is inside that form. If neither
+# appears, the fault is the repository or GitHub, and no edit to the form will
+# fix it.
+#
+# Delete this file once the answer is known.
+name: Probe form
+description: Temporary diagnostic, safe to ignore
+body:
+  - type: input
+    id: probe
+    attributes:
+      label: Anything
+    validations:
+      required: true


### PR DESCRIPTION
The chooser shows only "Open a blank issue", so GitHub is not offering add-product.yml at all. Everything observable from outside the sign-in wall is correct: the file is a regular 100644 blob at .github/ISSUE_TEMPLATE/ on the default branch, 4256 bytes, served by raw and listed by the contents API; it validates clean against the published issue-forms schema; `name` is 17 characters, over the >3 that silently hides a form; there is no config.yml, no legacy ISSUE_TEMPLATE.md, and no org-level .github repository overriding it. The missing `novo-produto` label is not a cause — GitHub simply does not apply a label that does not exist.

That exhausts remote diagnosis: logged out, both the chooser and ?template= return a sign-in page, so the rendered result cannot be inspected from here. This probe is the experiment instead. It is the minimal form from GitHub's own documentation, without the dropdowns, accented labels and `labels:` key that add-product.yml carries, so which of the two appears in the chooser localises the fault to the form or to the repository.

Temporary by construction: it is deleted once the answer is in.