### PR TITLE
fix: insert a product without reordering its category file

### DIFF
--- a/tests/tools/add-product.test.js
+++ b/tests/tools/add-product.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const sharp = require('sharp');
 
@@ -220,6 +221,53 @@ describe('processIssue', () => {
     const first = allocateId(new Set(), NOW);
     const second = allocateId(new Set([first]), NOW);
     expect(second).not.toBe(first);
+  });
+});
+
+describe('insertProduct', () => {
+  const { insertProduct } = require('../../tools/authoring/add-product');
+
+  // The committed files are not in listedAt order — the site sorts at display
+  // time, so the order on disk never mattered. Sorting on insert therefore
+  // rewrote whole files: PR #91 added one product to tshirts-casual-man and
+  // came out +277/-258, which a reviewer cannot read as "one product added".
+  const catalogDir = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'insert-'));
+    fs.writeFileSync(
+      path.join(dir, 'caps-man.json'),
+      `${JSON.stringify(
+        [
+          { id: '0304251751', brand: 'nike', price: 39, sizes: [], images: ['images/man/caps/0304251751-nike.jpeg'], listedAt: '2025-04-03T17:51:00Z' },
+          { id: '2910251954', brand: 'adidas', price: 49, sizes: [], images: ['images/man/caps/2910251954-adidas.jpeg'], listedAt: '2025-10-29T19:54:00Z' },
+          { id: '1707251459', brand: 'puma', price: 45, sizes: [], images: ['images/man/caps/1707251459-puma.jpeg'], listedAt: '2025-07-17T14:59:00Z' },
+        ],
+        null,
+        4
+      )}\n`
+    );
+    return dir;
+  };
+
+  const added = { id: '2208262009', brand: 'brooksfield', price: 101.5, sizes: [], images: ['images/man/caps/2208262009-brooksfield.jpeg'], listedAt: '2026-08-22T20:09:00Z' };
+
+  it('adds the product without moving any other', async () => {
+    const dir = catalogDir();
+    const before = JSON.parse(fs.readFileSync(path.join(dir, 'caps-man.json'), 'utf8'));
+
+    const count = await insertProduct('caps-man', added, dir);
+    const after = JSON.parse(fs.readFileSync(path.join(dir, 'caps-man.json'), 'utf8'));
+
+    expect(count).toBe(4);
+    expect(after[0].id).toBe(added.id);
+    expect(after.slice(1)).toEqual(before);
+  });
+
+  it('leaves the file re-serialisable without a diff', async () => {
+    const dir = catalogDir();
+    await insertProduct('caps-man', added, dir);
+    const raw = fs.readFileSync(path.join(dir, 'caps-man.json'), 'utf8');
+
+    expect(raw).toBe(`${JSON.stringify(JSON.parse(raw), null, 4)}\n`);
   });
 });
 

--- a/tools/authoring/add-product.js
+++ b/tools/authoring/add-product.js
@@ -109,20 +109,26 @@ const reencode = async (bytes) => {
 };
 
 /**
- * Inserts a product into its category file, newest first.
+ * Inserts a product at the head of its category file.
  *
  * Parsed and re-serialised rather than appended textually, so a crafted value
- * cannot break out of the JSON.
+ * cannot break out of the JSON. Nothing but the new entry moves: sorting the
+ * array here rewrote the whole file, because the committed order is not
+ * listedAt order, and buried one added product under a few hundred lines of
+ * reordering that a reviewer then had to read to be sure nothing else changed.
+ * Nothing needed that sort — display order is derived, by buildAllCatalog for
+ * products/all.json and by scripts.js for the in-browser fallback — so the
+ * order on disk is cosmetic.
  * @param {string} category Category slug.
  * @param {object} product The product to add.
+ * @param {string} [productsDir] Directory holding the category files.
  * @returns {Promise<number>} The resulting product count.
  */
-const insertProduct = async (category, product) => {
-  const file = path.join(PRODUCTS_DIR, `${category}.json`);
-  const products = readCategory(PRODUCTS_DIR, category);
+const insertProduct = async (category, product, productsDir = PRODUCTS_DIR) => {
+  const file = path.join(productsDir, `${category}.json`);
+  const products = readCategory(productsDir, category);
 
   products.unshift(product);
-  products.sort((a, b) => Date.parse(b.listedAt) - Date.parse(a.listedAt));
 
   await fsp.writeFile(file, `${JSON.stringify(products, null, 4)}\n`, 'utf8');
   return products.length;


### PR DESCRIPTION
PR #91 added one product to tshirts-casual-man and came out +277/-258: insertProduct sorted the whole array by listedAt after unshifting, and the committed files are not in listedAt order — that file starts at 0304251751 while its newest entry is 2910251954. So every submission rewrote its category file, and the reviewer whose approval is the second of the two checks this path relies on could not see what had changed.

Nothing needed the sort. Display order is derived twice over, by buildAllCatalog for products/all.json and by scripts.js:401 for the in-browser fallback, so the order on disk is cosmetic. Dropping it makes the same insertion +19/-0, and re-serialising is already byte-identical to what is committed, so the new entry is the entire diff.

insertProduct takes the products directory as an argument now, defaulted so callers are unchanged, because the regression is only observable by writing a file: the two tests build a category whose order is deliberately not listedAt order, then assert the other entries come back untouched and the result still round-trips through JSON.stringify.